### PR TITLE
Tweak to the documentation:  put short descriptions before Behavior and Event data families.

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Model.hs
+++ b/reactive-banana/src/Reactive/Banana/Model.hs
@@ -32,7 +32,22 @@ import Data.Monoid
 {-----------------------------------------------------------------------------
     Class interface
 ------------------------------------------------------------------------------}
+{- | @Event f a@ represents a stream of events as they occur in time.
+Semantically, you can think of @Event f a@ as an infinite list of values
+that are tagged with their corresponding time of occurence,
+
+> type Event f a = [(Time,a)]
+
+See the typeclass 'FRP' for more details.
+-}
 data family Event f    :: * -> *
+
+{- | Behavior f a represents a value that varies in time. Think of it as
+
+> type Behavior f a = Time -> a
+
+See the typeclass 'FRP' for more details.
+-}
 data family Behavior f :: * -> *
 
 {- | The 'FRP' class defines the primitive API for functional reactive programming.


### PR DESCRIPTION
At the moment the documentation describing what Behavior and Event are
appears in the FRP class, but not next to the definitions themselves, which is
significant because the definitions are to where all of the hyperlinks lead. This
patch copies a short description from the FRP documentation to Behavior
and Event, and also adds a link back to the FRP typeclass for more details.
