### PR TITLE
Layout fix for the example code in Reactive.Banana.Frameworks

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Frameworks.hs
+++ b/reactive-banana/src/Reactive/Banana/Frameworks.hs
@@ -141,10 +141,10 @@ primInitial ~(Prim.StepperB x e) = x
 >           reactimate $ fmap print event15
 >           reactimate $ fmap drawCircle eventCircle
 >
->       -- compile network description into a network
->       network <- compile networkDescription
->       -- register handlers and start producing outputs
->       actuate network
+>   -- compile network description into a network
+>   network <- compile networkDescription
+>   -- register handlers and start producing outputs
+>   actuate network
 
     In short, you use 'fromAddHandler' to obtain /input/ events.
     The library uses this to register event handlers


### PR DESCRIPTION
I think there's an error in the example code for this module. `compile networkDescription`
and `actuate network` are IO actions, so they should align with the other statements in the
`main` do-block. Currently they align with the `networkDescription` let statement.

I'm quite new to Reactive Banana, so it's entirely possible that I'm misunderstanding
what's supposed to be going on here. If so, I'm confused, and I'd appreciate being set
straight!
