### PR TITLE
Fix build dependencies, requires at least containers-0.5

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -58,7 +58,7 @@ Library
                         NoMonomorphismRestriction
     
     build-depends:      base >= 4.2 && < 5,
-                        containers >= 0.3 && < 0.6,
+                        containers >= 0.5 && < 0.6,
                         transformers >= 0.2 && < 0.5,
                         vault == 0.3.*
 


### PR DESCRIPTION
Data.IntMap.Strict is used, which was only introduced with 0.5.
