### PR TITLE
Forget seen elements after they are processed

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Dependencies.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Dependencies.hs
@@ -125,10 +125,10 @@ insert k a q@(DQ queue seen) = {-# SCC insert #-}
         then q
         else DQ (Q.insert k a queue) (Set.insert a seen)
 
-minView :: DepsQueue a -> Maybe (a, DepsQueue a)
+minView :: (Eq a, Hashable a) => DepsQueue a -> Maybe (a, DepsQueue a)
 minView (DQ queue seen) = {-# SCC minView #-} case Q.minView queue of
     Nothing          -> Nothing
-    Just (a, queue2) -> Just (a, DQ queue2 seen)
+    Just (a, queue2) -> Just (a, DQ queue2 (Set.delete a seen))
 
 {-----------------------------------------------------------------------------
     Small tests


### PR DESCRIPTION
I am not familiar enough with the internals of reactive-banana to be sure that this is the correct fix for #79, but it does fix that issue and `cabal test` still succeeds.

The idea of the fix is to change `DepsQueue` so that instead of ignoring insertions of elements which have already been inserted at some point in the past, we now only ignore the elements which are currently in the queue. The implementation uses the fact that `insert` is adding the elements it inserts into `seen` and ignores the elements which are already in there; my fix is to remove elements from `seen` once they are dequeued. As a bonus, `seen` is no longer growing without bounds.

I have no idea what this queue is used for, other than the fact that it deduplicates elements and that #79 was introduced when DepsQueue was added. In the context in which it is used, does it make sense to allow the same element to be added to the queue a second time if the element which was first added has already been processed? If you are adding an element which is already in the queue, instead of ignoring it, perhaps it would make sense to readjust its priority?