### PR TITLE
never use ensureAbove

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Dependencies.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Dependencies.hs
@@ -62,7 +62,7 @@ addChild parent child deps1@(Deps{..}) = deps2
     deps2 = Deps
         { dChildren = Map.insertWith (++) parent [child] dChildren
         , dParents  = Map.insertWith (++) child [parent] dParents
-        , dOrder    = ensureAbove child parent dOrder
+        , dOrder    = recalculateParent child parent (parents deps2) dOrder
         }
     when b f = if b then f else id
 

--- a/reactive-banana/src/Reactive/Banana/Prim/Order.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Order.hs
@@ -8,7 +8,7 @@ module Reactive.Banana.Prim.Order (
     
     -- * Order
     Order, flat,
-    ensureAbove, recalculateParent,
+    recalculateParent,
     Level, level,
     
     ) where
@@ -48,12 +48,6 @@ ground = 0
 -- | Look up the level of an element. Default level is 'ground'.
 level :: (Eq a, Hashable a) => a -> Order a -> Level
 level x = {-# SCC level #-} maybe ground id . Map.lookup x
-
--- | Make sure that the first argument is at least one level
--- above the second argument.
-ensureAbove :: (Eq a, Hashable a) => a -> a -> Order a -> Order a
-ensureAbove child parent order =
-    Map.insertWith max child (level parent order + 1) order
 
 -- | Reassign the parent for a child and recalculate the levels
 -- for the new parents and grandparents.


### PR DESCRIPTION
Unlike recalculateParent, ensureAbove wasn't maintaining the invariant
that all children have a higher level than their parent.