### PR TITLE
Make MonadFix superclass of MonadMoment

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Types.hs
@@ -120,7 +120,7 @@ instance MonadIO MomentIO where liftIO = MIO . liftIO
 that happens at one particular moment in time.
 Unlike the 'Moment' monad, it need not be pure anymore.
 -}
-class Monad m => MonadMoment m where
+class MonadFix m => MonadMoment m where
     liftMoment :: Moment a -> m a
 
 instance MonadMoment Moment   where liftMoment = id


### PR DESCRIPTION
Since there are exactly two instances, `MomentIO` and `Moment`, both already MonadFix, this should be correct.
