### PR TITLE
Pull-based behaviors?

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Frameworks.hs
+++ b/reactive-banana/src/Reactive/Banana/Frameworks.hs
@@ -18,7 +18,7 @@ module Reactive.Banana.Frameworks (
     -- ** Core functions
     compile, MomentIO,
     module Control.Event.Handler,
-    fromAddHandler, fromChanges, fromPoll,
+    fromAddHandler, fromChanges, fromPoll, fromPull,
     reactimate, Future, reactimate',
     changes,
     -- $changes
@@ -184,6 +184,9 @@ fromAddHandler = MIO . fmap E . Prim.fromAddHandler
 -- Neither should its side effects affect the event network significantly.
 fromPoll :: IO a -> MomentIO (Behavior a)
 fromPoll = MIO . fmap B . Prim.fromPoll
+
+fromPull :: IO a -> MomentIO (Behavior a)
+fromPull = MIO . fmap B . Prim.fromPull
 
 -- | Input,
 -- obtain a 'Behavior' from an 'AddHandler' that notifies changes.

--- a/reactive-banana/src/Reactive/Banana/Prim/Plumbing.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Plumbing.hs
@@ -96,6 +96,34 @@ newLatch a = mdo
     
     return (updateOn, latch)
 
+-- | Make a new 'Latch' which runs an IO whenever it is checked.
+--   FIXME Please review this. Ideally the IO would run at most once per
+--   cycle.
+newLatchIO :: IO a -> Build (Latch a)
+newLatchIO ioa = mdo
+    a <- liftIO ioa
+    latch <- liftIO $ newRef $ Latch
+        { _seenL  = beginning
+        , _valueL = a
+        , _evalL  = do
+            Latch {..} <- readRef latch
+            RW.tell _seenL
+            a <- liftIO ioa
+            modify' latch (\x -> x { _valueL = a })
+            pure a
+        }
+    w <- liftIO $ mkWeakRefValue latch latch
+    lw <- liftIO $ newRef $ LatchWrite
+        { _evalLW = do
+            Latch {..} <- readRef latch
+            pure _valueL
+        , _latchLW = w
+        }
+    _ <- liftIO $ mkWeakRefValue latch lw
+    always <- alwaysP
+    (P always) `addChild` (L lw)
+    pure latch
+
 -- | Make a new 'Latch' that caches a previous computation.
 cachedLatch :: EvalL a -> Latch a
 cachedLatch eval = unsafePerformIO $ mdo


### PR DESCRIPTION
The motivation: when doing DOM programming we sometimes wish to deal
with the dimensions of elements. It seems natural to say that there is a
`Behavior Rect` for an element's bounding client rectangle. But how to
construct such a thing?? We would need an event to give the changes, but
the DOM doesn't supply that, and polling it would probably grow
prohibitively expensive. Why not compute it on-demand?

This patch defines `fromPull :: IO a -> MomentIO (Behavior a)` to
produce pull-based behaviors. Ideally, the IO would run at most once
per evaluation of the network. In this implementation, it's run at
least 0 times. I have a feeling I'm doing something horribly wrong in
`newLatchIO`.

What do you think? Good idea? Not so good? Consider this a feature request with code attached.