### PR TITLE
Add paintB for easy repainting with behaviors in reactive-banana-wx

### DIFF
--- a/reactive-banana-wx/src/Reactive/Banana/WX.hs
+++ b/reactive-banana-wx/src/Reactive/Banana/WX.hs
@@ -11,6 +11,7 @@ module Reactive.Banana.WX (
     -- * General
     event1, event0, behavior,
     Prop'(..), sink,
+    paintB,
     module Reactive.Banana.Frameworks,
     
     -- * Specific widgets
@@ -65,6 +66,14 @@ sink widget = mapM_ sink1
         liftIOLater $ set widget [attr := x]
         e <- changes b
         reactimate' $ (fmap $ \x -> set widget [attr := x]) <$> e
+
+-- | Repaint a widget with a behavior whenever the behavior changes.
+paintB :: Paint w => w -> Behavior (DC () -> Rect -> IO ()) -> MomentIO ()
+paintB w b = do
+    x <- valueBLater b
+    liftIOLater $ set w [on paint := x]
+    e <- changes b
+    reactimate' $ (fmap $ \y -> set w [on paint := y] >> repaint w) <$> e
 
 {-----------------------------------------------------------------------------
     Specific widgets


### PR DESCRIPTION
`paintB` is a helper function that updates a widget's `on paint` handler based on a `Behavior` and triggers a `repaint` whenever the `Behavior` changes.