### PR TITLE
Fix Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.cabal-sandbox
 *.DS_Store
 *.tmproj
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1],  sources: [hvr-ghc]}}
+  allow_failures:
+    - env: CABALVER=1.24 GHCVER=8.0.1
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:

--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -23,7 +23,7 @@ License-file:        LICENSE
 Author:              Heinrich Apfelmus
 Maintainer:          Heinrich Apfelmus <apfelmus quantentunnel de>
 Category:            FRP
-Cabal-version:       >= 1.18
+Cabal-version:       >= 1.16
 Build-type:          Simple
 
 extra-source-files:     CHANGELOG.md,


### PR DESCRIPTION
The Travis config is set to test with 1.16, but the minimum supported Cabal version is set to 1.18. This is causing Travis to error out all the time.

Let's try setting the minimum supported Cabal version to 1.16. Will Travis like this better?