### PR TITLE
Fix #124: adapt to GHC-8.0.1.

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Util.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-----------------------------------------------------------------------------
     reactive-banana
 ------------------------------------------------------------------------------}
@@ -50,8 +51,13 @@ modify' ~(Ref ref _) f = liftIO $ readIORef ref >>= \x -> writeIORef ref $! f x
     Weak pointers
 ------------------------------------------------------------------------------}
 mkWeakIORefValueFinalizer :: IORef a -> value -> IO () -> IO (Weak value)
+#if MIN_VERSION_base(4,9,0)
 mkWeakIORefValueFinalizer r@(GHC.IORef (GHC.STRef r#)) v (GHC.IO f) = GHC.IO $ \s ->
   case GHC.mkWeak# r# v f s of (# s1, w #) -> (# s1, GHC.Weak w #)
+#else
+mkWeakIORefValueFinalizer r@(GHC.IORef (GHC.STRef r#)) v f = GHC.IO $ \s ->
+  case GHC.mkWeak# r# v f s of (# s1, w #) -> (# s1, GHC.Weak w #)
+#endif
 
 mkWeakIORefValue :: IORef a -> value -> IO (Weak value)
 mkWeakIORefValue a b = mkWeakIORefValueFinalizer a b (return ())

--- a/reactive-banana/src/Reactive/Banana/Prim/Util.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Util.hs
@@ -50,7 +50,7 @@ modify' ~(Ref ref _) f = liftIO $ readIORef ref >>= \x -> writeIORef ref $! f x
     Weak pointers
 ------------------------------------------------------------------------------}
 mkWeakIORefValueFinalizer :: IORef a -> value -> IO () -> IO (Weak value)
-mkWeakIORefValueFinalizer r@(GHC.IORef (GHC.STRef r#)) v f = GHC.IO $ \s ->
+mkWeakIORefValueFinalizer r@(GHC.IORef (GHC.STRef r#)) v (GHC.IO f) = GHC.IO $ \s ->
   case GHC.mkWeak# r# v f s of (# s1, w #) -> (# s1, GHC.Weak w #)
 
 mkWeakIORefValue :: IORef a -> value -> IO (Weak value)


### PR DESCRIPTION
Now builds with GHC 8.0.1

They changed GHC.Prim.mkWeak# signature from:
`mkWeak# :: o -> b -> c -> State# RealWorld -> (#State# RealWorld, Weak# b#)`
to: 
`mkWeak# :: o -> b -> (State# RealWorld -> (#State# RealWorld, c#)) -> State# RealWorld -> (#State# RealWorld, Weak# b#)`
Basically `c` type variable is now unpacked IO value.
