### PR TITLE
Simplify mkWeakIORefValue

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Util.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-----------------------------------------------------------------------------
     reactive-banana
 ------------------------------------------------------------------------------}
@@ -50,17 +49,9 @@ modify' ~(Ref ref _) f = liftIO $ readIORef ref >>= \x -> writeIORef ref $! f x
 {-----------------------------------------------------------------------------
     Weak pointers
 ------------------------------------------------------------------------------}
-mkWeakIORefValueFinalizer :: IORef a -> value -> IO () -> IO (Weak value)
-#if MIN_VERSION_base(4,9,0)
-mkWeakIORefValueFinalizer r@(GHC.IORef (GHC.STRef r#)) v (GHC.IO f) = GHC.IO $ \s ->
-  case GHC.mkWeak# r# v f s of (# s1, w #) -> (# s1, GHC.Weak w #)
-#else
-mkWeakIORefValueFinalizer r@(GHC.IORef (GHC.STRef r#)) v f = GHC.IO $ \s ->
-  case GHC.mkWeak# r# v f s of (# s1, w #) -> (# s1, GHC.Weak w #)
-#endif
-
 mkWeakIORefValue :: IORef a -> value -> IO (Weak value)
-mkWeakIORefValue a b = mkWeakIORefValueFinalizer a b (return ())
+mkWeakIORefValue (GHC.IORef (GHC.STRef r#)) val = GHC.IO $ \s ->
+  case GHC.mkWeakNoFinalizer# r# val s of (# s1, w #) -> (# s1, GHC.Weak w #)
 
 mkWeakRefValue :: MonadIO m => Ref a -> value -> m (Weak value)
 mkWeakRefValue (Ref ref _) v = liftIO $ mkWeakIORefValue ref v


### PR DESCRIPTION
This is equivalent to the old code, but without the need to check the version of base.

This change was inspired by looking at the source code for System.Mem.Weak.mkWeak in base.

I will not be offended if you reject this PR. I recognize that there is always risk when changing code, and since this code does the same thing as before, it may not be worth merging.

I have tested this code on GHC 7.8, 7.10, and 8.0. The tests pass on each of those three versions.