### PR TITLE
Add 'intersectionWith', 'mergeWith' combinators

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,7 +18,8 @@ Peter Minten
 Atze van der Ploeg
 Gideon Sireling
 Michael Smith
-Lennart Spitzner	<https://github.com/lspitzner>
+Lennart Spitzner    <https://github.com/lspitzner>
 Henning Thielemann
 Alexey Vagarenko
 Daniel Werner
+Mitchell Rosen      <https://github.com/mitchellwrosen>

--- a/reactive-banana/CHANGELOG.md
+++ b/reactive-banana/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog for the `reactive-banana** package
 -------------------------------------------
 
+**unreleased**
+
+* Add `mergeWith` combinator. [#163][]
+
+  [#163] https://github.com/HeinrichApfelmus/reactive-banana/pull/163
+
 **version 1.2.1.0**
 
 * Add `Num`, `Floating`, `Fractional`, and `IsString` instances for `Behavior`. [#34][]

--- a/reactive-banana/src/Reactive/Banana/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Combinators.hs
@@ -19,7 +19,7 @@ module Reactive.Banana.Combinators (
     -- but they are documented at the types 'Event' and 'Behavior'.
     module Control.Applicative,
     module Data.Semigroup,
-    never, unionWith, filterE,
+    never, unionWith, mergeWith, filterE,
     apply,
 
     -- ** Moment and accumulation
@@ -112,11 +112,14 @@ never = E Prim.never
 unionWith :: (a -> a -> a) -> Event a -> Event a -> Event a
 unionWith f = mergeWith Just Just (\x y -> Just (f x y))
 
--- | The most general form of merging two 'Event's.
+-- | Merge two event streams of any type.
+--
+-- This function generalizes 'unionWith', and can be used to filter event
+-- occurrences as well.
 mergeWith
-  :: (a -> Maybe c) -- ^ The function called when only the first 'Event' emits a value.
-  -> (b -> Maybe c) -- ^ The function called when only the second 'Event' emits a value.
-  -> (a -> b -> Maybe c) -- ^ The function called when both 'Event's emit values simultaneously.
+  :: (a -> Maybe c) -- ^ The function called when only the first event emits a value.
+  -> (b -> Maybe c) -- ^ The function called when only the second event emits a value.
+  -> (a -> b -> Maybe c) -- ^ The function called when both events emit values simultaneously.
   -> Event a
   -> Event b
   -> Event c

--- a/reactive-banana/src/Reactive/Banana/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Combinators.hs
@@ -110,7 +110,17 @@ never = E Prim.never
 -- >    | timex >  timey = (timey,y)     : unionWith f ((timex,x):xs) ys
 -- >    | timex == timey = (timex,f x y) : unionWith f xs ys
 unionWith :: (a -> a -> a) -> Event a -> Event a -> Event a
-unionWith f e1 e2 = E $ Prim.unionWith f (unE e1) (unE e2)
+unionWith f = mergeWith Just Just (\x y -> Just (f x y))
+
+-- | The most general form of merging two 'Event's.
+mergeWith
+  :: (a -> Maybe c) -- ^ The function called when only the first 'Event' emits a value.
+  -> (b -> Maybe c) -- ^ The function called when only the second 'Event' emits a value.
+  -> (a -> b -> Maybe c) -- ^ The function called when both 'Event's emit values simultaneously.
+  -> Event a
+  -> Event b
+  -> Event c
+mergeWith f g h e1 e2 = E $ Prim.mergeWith f g h (unE e1) (unE e2)
 
 -- | Allow all event occurrences that are 'Just' values, discard the rest.
 -- Variant of 'filterE'.

--- a/reactive-banana/src/Reactive/Banana/Prim.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim.hs
@@ -8,34 +8,34 @@ module Reactive.Banana.Prim (
     -- implemented your own FRP library.
     -- If you just want to use FRP in your project,
     -- have a look at "Reactive.Banana" instead.
-    
+
     -- * Evaluation
     Step, Network, emptyNetwork,
-    
+
     -- * Build FRP networks
     Build, liftIOLater, BuildIO, liftBuild, buildLater, buildLaterReadNow, compile,
     module Control.Monad.IO.Class,
-    
+
     -- * Caching
     module Reactive.Banana.Prim.Cached,
-    
+
     -- * Testing
     interpret, mapAccumM, mapAccumM_, runSpaceProfile,
-    
+
     -- * IO
     newInput, addHandler, readLatch,
-    
+
     -- * Pulse
     Pulse,
-    neverP, alwaysP, mapP, Future, tagFuture, unsafeMapIOP, filterJustP, unionWithP,
-    
+    neverP, alwaysP, mapP, Future, tagFuture, unsafeMapIOP, filterJustP, mergeWithP,
+
     -- * Latch
     Latch,
     pureL, mapL, applyL, accumL, applyP,
-    
+
     -- * Dynamic event switching
     switchL, executeP, switchP
-    
+
     -- * Notes
     -- $recursion
   ) where

--- a/reactive-banana/src/Reactive/Banana/Prim/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Combinators.hs
@@ -58,19 +58,24 @@ unsafeMapIOP f p1 = do
     eval (Just x) = Just <$> liftIO (f x)
     eval Nothing  = return Nothing
 
-unionWithP :: forall a. (a -> a -> a) -> Pulse a -> Pulse a -> Build (Pulse a)
-unionWithP f px py = do
-        p <- newPulse "unionWithP" $
-            {-# SCC unionWithP #-} eval <$> readPulseP px <*> readPulseP py
-        p `dependOn` px
-        p `dependOn` py
-        return p
-    where
-    eval :: Maybe a -> Maybe a -> Maybe a
-    eval (Just x) (Just y) = Just (f x y)
-    eval (Just x) Nothing  = Just x
-    eval Nothing  (Just y) = Just y
+mergeWithP
+  :: (a -> Maybe c)
+  -> (b -> Maybe c)
+  -> (a -> b -> Maybe c)
+  -> Pulse a
+  -> Pulse b
+  -> Build (Pulse c)
+mergeWithP f g h px py = do
+  p <- newPulse "mergeWithP" $
+       {-# SCC mergeWithP #-} eval <$> readPulseP px <*> readPulseP py
+  p `dependOn` px
+  p `dependOn` py
+  return p
+  where
     eval Nothing  Nothing  = Nothing
+    eval (Just x) Nothing  = f x
+    eval Nothing  (Just y) = g y
+    eval (Just x) (Just y) = h x y
 
 -- See note [LatchRecursion]
 applyP :: Latch (a -> b) -> Pulse a -> Build (Pulse b)

--- a/reactive-banana/src/Reactive/Banana/Test.hs
+++ b/reactive-banana/src/Reactive/Banana/Test.hs
@@ -33,7 +33,7 @@ main = defaultMain
         [ testModelMatchM "counter"     counter
         , testModelMatch "double"      double
         , testModelMatch "sharing"     sharing
-        , testModelMatch "unionFilter" unionFilter
+        , testModelMatch "mergeFilter" mergeFilter
         , testModelMatchM "recursive1A"  recursive1A
         , testModelMatchM "recursive1B"  recursive1B
         , testModelMatchM "recursive2"  recursive2
@@ -111,14 +111,14 @@ counter e = do
     bcounter <- accumB 0 $ fmap (\_ -> (+1)) e
     return $ applyE (pure const <*> bcounter) e
 
-merge e1 e2 = unionWith (++) (list e1) (list e2)
+merge e1 e2 = mergeWith Just Just (\x y -> Just (x ++ y)) (list e1) (list e2)
     where list = fmap (:[])
 
 double e  = merge e e
 sharing e = merge e1 e1
     where e1 = filterE (< 3) e
 
-unionFilter e1 = unionWith (+) e2 e3
+mergeFilter e1 = mergeWith Just Just (\x y -> Just (x + y)) e2 e3
     where
     e3 = fmap (+1) $ filterE even e1
     e2 = fmap (+1) $ filterE odd  e1
@@ -245,9 +245,9 @@ issue79 inputEvent = mdo
         fmappedEvent  = fmap id (filteredEvent)
     lastValue <- stepper 1 $ fmappedEvent
 
-    let outputEvent = unionWith (++)
+    let outputEvent = mergeWith Just Just (\x y -> Just (x ++ y))
             (const "filtered event" <$> filteredEvent)
-            (((" and " ++) . show) <$> unionWith (+) appliedEvent fmappedEvent)
+            (((" and " ++) . show) <$> mergeWith Just Just (\x y -> Just (x + y)) appliedEvent fmappedEvent)
 
     return $ outputEvent
 

--- a/reactive-banana/src/Reactive/Banana/Test/Plumbing.hs
+++ b/reactive-banana/src/Reactive/Banana/Test/Plumbing.hs
@@ -41,11 +41,11 @@ interpretGraph f = Y.interpret (fmap sndE . sndM . f . ey)
 {-----------------------------------------------------------------------------
     Primitive combinators
 ------------------------------------------------------------------------------}
-never                           = E X.never Y.never
-filterJust (E x y)              = E (X.filterJust x) (Y.filterJust y)
-unionWith f (E x1 y1) (E x2 y2) = E (X.unionWith f x1 x2) (Y.unionWith f y1 y2)
-mapE f (E x y)                  = E (fmap f x) (Y.mapE f y)
-applyE ~(B x1 y1) (E x2 y2)     = E (X.apply x1 x2) (Y.applyE y1 y2)
+never                               = E X.never Y.never
+filterJust (E x y)                  = E (X.filterJust x) (Y.filterJust y)
+mergeWith f g h (E x1 y1) (E x2 y2) = E (X.mergeWith f g h x1 x2) (Y.mergeWith f g h y1 y2)
+mapE f (E x y)                      = E (fmap f x) (Y.mapE f y)
+applyE ~(B x1 y1) (E x2 y2)         = E (X.apply x1 x2) (Y.applyE y1 y2)
 
 instance Functor Event where fmap = mapE
 

--- a/reactive-banana/src/Reactive/Banana/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Types.hs
@@ -52,7 +52,7 @@ instance Functor Event where
 -- > (<>) :: Event a -> Event a -> Event a
 -- > (<>) ex ey = unionWith (<>) ex ey
 instance Semigroup a => Semigroup (Event a) where
-    x <> y = E $ Prim.unionWith (<>) (unE x) (unE y)
+    x <> y = E $ Prim.mergeWith Just Just (\a b -> Just (a <> b)) (unE x) (unE y)
 
 -- | The combinator 'mempty' represents an event that never occurs.
 -- It is a synonym,


### PR DESCRIPTION
In case you want it, this patch adds `intersectionWith` and `mergeWith` (#158) (though I prefer the names `intersection` and `merge`) Sorry about all the whitespace changes, my editor deletes trailing spaces on save.