### PR TITLE
RFC: pulse parents are not really weak references

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Types.hs
@@ -99,7 +99,7 @@ data Pulse' a = Pulse
     , _seenP     :: !Time              -- See note [Timestamp].
     , _evalP     :: EvalP (Maybe a)    -- Calculate current value.
     , _childrenP :: [Weak SomeNode]    -- Weak references to child nodes.
-    , _parentsP  :: [Weak SomeNode]    -- Weak reference to parent nodes.
+    , _parentsP  :: [SomeNode]         -- References to parent nodes. Invariant: they are all pulses.
     , _levelP    :: !Level             -- Priority in evaluation order.
     , _nameP     :: String             -- Name for debugging.
     }
@@ -156,7 +156,7 @@ seenL = Lens _seenL  (\a s -> s { _seenL = a })
 valueL :: Lens (Latch' a) a
 valueL = Lens _valueL (\a s -> s { _valueL = a })
 
-parentsP :: Lens (Pulse' a) [Weak SomeNode]
+parentsP :: Lens (Pulse' a) [SomeNode]
 parentsP = Lens _parentsP (\a s -> s { _parentsP = a })
 
 childrenP :: Lens (Pulse' a) [Weak SomeNode]

--- a/reactive-banana/src/Reactive/Banana/Prim/Util.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Util.hs
@@ -29,7 +29,7 @@ nop = return ()
 ------------------------------------------------------------------------------}
 data Ref a = Ref !(IORef a) !Unique
 
-instance Hashable (Ref a) where hashWithSalt s (Ref _ u) = hashWithSalt s u 
+instance Hashable (Ref a) where hashWithSalt s (Ref _ u) = hashWithSalt s u
 
 equalRef :: Ref a -> Ref b -> Bool
 equalRef (Ref _ a) (Ref _ b) = a == b


### PR DESCRIPTION
Hi, I have some code attached to a question I have about the implementation. It seems to me that a pulse child will always keep its pulse parent alive, yet the parents field is a `[Weak SomeNode]`. So, I changed this to a `[SomeNode]` and chased down all of the type errors.

Does this change make sense? Thanks.