### PR TITLE
Remove a couple uses of unsafePerformIO

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
@@ -133,12 +133,13 @@ changesB = liftCached1 $ \(~(lx,px)) -> liftBuild $ Prim.tagFuture lx px
 pureB :: a -> Behavior a
 pureB a = cache $ do
     p <- runCached never
-    return (Prim.pureL a, p)
+    l <- Prim.pureL a
+    return (l, p)
 
 applyB :: Behavior (a -> b) -> Behavior a -> Behavior b
 applyB = liftCached2 $ \(~(l1,p1)) (~(l2,p2)) -> liftBuild $ do
     p3 <- Prim.unionWithP const p1 p2
-    let l3 = Prim.applyL l1 l2
+    l3 <- Prim.applyL l1 l2
     return (l3,p3)
 
 mapB :: (a -> b) -> Behavior a -> Behavior b

--- a/reactive-banana/src/Reactive/Banana/Prim.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim.hs
@@ -8,34 +8,34 @@ module Reactive.Banana.Prim (
     -- implemented your own FRP library.
     -- If you just want to use FRP in your project,
     -- have a look at "Reactive.Banana" instead.
-    
+
     -- * Evaluation
     Step, Network, emptyNetwork,
-    
+
     -- * Build FRP networks
     Build, liftIOLater, BuildIO, liftBuild, buildLater, buildLaterReadNow, compile,
     module Control.Monad.IO.Class,
-    
+
     -- * Caching
     module Reactive.Banana.Prim.Cached,
-    
+
     -- * Testing
     interpret, mapAccumM, mapAccumM_, runSpaceProfile,
-    
+
     -- * IO
     newInput, addHandler, readLatch,
-    
+
     -- * Pulse
     Pulse,
     neverP, alwaysP, mapP, Future, tagFuture, unsafeMapIOP, filterJustP, unionWithP,
-    
+
     -- * Latch
     Latch,
     pureL, mapL, applyL, accumL, applyP,
-    
+
     -- * Dynamic event switching
     switchL, executeP, switchP
-    
+
     -- * Notes
     -- $recursion
   ) where
@@ -46,7 +46,7 @@ import Reactive.Banana.Prim.Cached
 import Reactive.Banana.Prim.Combinators
 import Reactive.Banana.Prim.Compile
 import Reactive.Banana.Prim.IO
-import Reactive.Banana.Prim.Plumbing (neverP, alwaysP, liftBuild, buildLater, buildLaterReadNow, liftIOLater)
+import Reactive.Banana.Prim.Plumbing (neverP, alwaysP, pureL, liftBuild, buildLater, buildLaterReadNow, liftIOLater)
 import Reactive.Banana.Prim.Types
 
 {-----------------------------------------------------------------------------

--- a/reactive-banana/src/Reactive/Banana/Prim/Plumbing.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Plumbing.hs
@@ -64,8 +64,8 @@ neverP = liftIO $ do
         }
 
 -- | Return a 'Latch' that has a constant value
-pureL :: a -> Latch a
-pureL a = unsafePerformIO $ newRef $ Latch
+pureL :: MonadIO m => a -> m (Latch a)
+pureL a = newRef Latch
     { _seenL  = beginning
     , _valueL = a
     , _evalL  = return a
@@ -99,8 +99,8 @@ newLatch a = mdo
     return (updateOn, latch)
 
 -- | Make a new 'Latch' that caches a previous computation.
-cachedLatch :: EvalL a -> Latch a
-cachedLatch eval = unsafePerformIO $ mdo
+cachedLatch :: EvalL a -> Build (Latch a)
+cachedLatch eval = mdo
     latch <- newRef $ Latch
         { _seenL  = agesAgo
         , _valueL = error "Undefined value of a cached latch."

--- a/reactive-banana/src/Reactive/Banana/Prim/Test.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Test.hs
@@ -16,7 +16,7 @@ test_accumL1 :: Pulse Int -> BuildIO (Pulse Int)
 test_accumL1 p1 = liftBuild $ do
     p2     <- mapP (+) p1
     (l1,_) <- accumL 0 p2
-    let l2 =  mapL const l1
+    l2     <- mapL const l1
     p3     <- applyP l2 p1
     return p3
 
@@ -25,7 +25,7 @@ test_recursion1 p1 = liftBuild $ mdo
     p2      <- applyP l2 p1
     p3      <- mapP (const (+1)) p2
     ~(l1,_) <- accumL (0::Int) p3
-    let l2  =  mapL const l1
+    l2      <- mapL const l1
     return p2
 
 -- test garbage collection


### PR DESCRIPTION
This patch strips `unsafePerformIO` from the definition of `pureL` and `cachedLatch`. Neither were ever called in a non-IO context so I simply had to translate `let x = ...` to `x <- ...`.