### PR TITLE
Add MonadUnliftIO instances

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -50,7 +50,8 @@ Library
                         vault == 0.3.*,
                         unordered-containers >= 0.2.1.0 && < 0.3,
                         hashable >= 1.1 && < 1.3,
-                        pqueue >= 1.0 && < 1.5
+                        pqueue >= 1.0 && < 1.5,
+                        unliftio-core >= 0.1 && < 0.2
 
     exposed-modules:
                         Control.Event.Handler,
@@ -87,6 +88,7 @@ Test-Suite tests
                         HUnit >= 1.2 && < 2,
                         test-framework >= 0.6 && < 0.9,
                         test-framework-hunit >= 0.2 && < 0.4,
+                        unliftio-core >= 0.1 && < 0.2,
                         reactive-banana, vault, containers,
                         semigroups, transformers,
                         unordered-containers, hashable, psqueues, pqueue


### PR DESCRIPTION
These instances would be quite useful for projects also using `UnliftIO`. It would bring in `unliftio-core` as a dependency, but that package only depends on `base` and `transformers`. 

(It does require `base >= 4.5`, which is inconsistent with `reactive-banana`'s dependency. I don't know if this is a problem.)