### PR TITLE
Loosen hashable and semigroups' upper bound

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -44,12 +44,12 @@ Library
     hs-source-dirs:     src
 
     build-depends:      base >= 4.2 && < 5,
-                        semigroups >= 0.13 && < 0.19,
+                        semigroups >= 0.13 && < 0.20,
                         containers >= 0.5 && < 0.7,
                         transformers >= 0.2 && < 0.6,
                         vault == 0.3.*,
                         unordered-containers >= 0.2.1.0 && < 0.3,
-                        hashable >= 1.1 && < 1.3,
+                        hashable >= 1.1 && < 1.4,
                         pqueue >= 1.0 && < 1.5
 
     exposed-modules:


### PR DESCRIPTION
Right now this package does not build with GHC 8.8.3, please consider revisioning, thanks.