### PR TITLE
Support building with GHC 9

### DIFF
--- a/reactive-banana/CHANGELOG.md
+++ b/reactive-banana/CHANGELOG.md
@@ -4,8 +4,10 @@ Changelog for the `reactive-banana** package
 **unreleased**
 
 * Add `mergeWith` combinator. [#163][]
+* Make internal SCC pragmas compatible with the GHC 9.0 parser. [#208][]
 
-  [#163] https://github.com/HeinrichApfelmus/reactive-banana/pull/163
+  [#163]: https://github.com/HeinrichApfelmus/reactive-banana/pull/163
+  [#208]: https://github.com/HeinrichApfelmus/reactive-banana/pull/208
 
 **version 1.2.1.0**
 

--- a/reactive-banana/src/Reactive/Banana/Prim/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Combinators.hs
@@ -26,7 +26,7 @@ debug s = id
 ------------------------------------------------------------------------------}
 mapP :: (a -> b) -> Pulse a -> Build (Pulse b)
 mapP f p1 = do
-    p2 <- newPulse "mapP" $ {-# SCC mapP #-} fmap f <$> readPulseP p1
+    p2 <- newPulse "mapP" $ ({-# SCC mapP #-} fmap f <$> readPulseP p1)
     p2 `dependOn` p1
     return p2
 
@@ -43,14 +43,14 @@ tagFuture x p1 = do
 
 filterJustP :: Pulse (Maybe a) -> Build (Pulse a)
 filterJustP p1 = do
-    p2 <- newPulse "filterJustP" $ {-# SCC filterJustP #-} join <$> readPulseP p1
+    p2 <- newPulse "filterJustP" $ ({-# SCC filterJustP #-} join <$> readPulseP p1)
     p2 `dependOn` p1
     return p2
 
 unsafeMapIOP :: forall a b. (a -> IO b) -> Pulse a -> Build (Pulse b)
 unsafeMapIOP f p1 = do
         p2 <- newPulse "unsafeMapIOP" $
-            {-# SCC unsafeMapIOP #-} eval =<< readPulseP p1
+            ({-# SCC unsafeMapIOP #-} eval =<< readPulseP p1)
         p2 `dependOn` p1
         return p2
     where
@@ -61,7 +61,7 @@ unsafeMapIOP f p1 = do
 unionWithP :: forall a. (a -> a -> a) -> Pulse a -> Pulse a -> Build (Pulse a)
 unionWithP f px py = do
         p <- newPulse "unionWithP" $
-            {-# SCC unionWithP #-} eval <$> readPulseP px <*> readPulseP py
+            ({-# SCC unionWithP #-} eval <$> readPulseP px <*> readPulseP py)
         p `dependOn` px
         p `dependOn` py
         return p
@@ -76,7 +76,7 @@ unionWithP f px py = do
 applyP :: Latch (a -> b) -> Pulse a -> Build (Pulse b)
 applyP f x = do
     p <- newPulse "applyP" $
-        {-# SCC applyP #-} fmap <$> readLatchP f <*> readPulseP x
+        ({-# SCC applyP #-} fmap <$> readLatchP f <*> readPulseP x)
     p `dependOn` x
     return p
 
@@ -85,11 +85,11 @@ pureL = Reactive.Banana.Prim.Plumbing.pureL
 
 -- specialization of   mapL f = applyL (pureL f)
 mapL :: (a -> b) -> Latch a -> Latch b
-mapL f lx = cachedLatch $ {-# SCC mapL #-} f <$> getValueL lx
+mapL f lx = cachedLatch $ ({-# SCC mapL #-} f <$> getValueL lx)
 
 applyL :: Latch (a -> b) -> Latch a -> Latch b
 applyL lf lx = cachedLatch $
-    {-# SCC applyL #-} getValueL lf <*> getValueL lx
+    ({-# SCC applyL #-} getValueL lf <*> getValueL lx)
 
 accumL :: a -> Pulse (a -> a) -> Build (Latch a, Pulse a)
 accumL a p1 = do
@@ -115,7 +115,7 @@ switchL l pl = mdo
 
 executeP :: forall a b. Pulse (b -> Build a) -> b -> Build (Pulse a)
 executeP p1 b = do
-        p2 <- newPulse "executeP" $ {-# SCC executeP #-} eval =<< readPulseP p1
+        p2 <- newPulse "executeP" $ ({-# SCC executeP #-} eval =<< readPulseP p1)
         p2 `dependOn` p1
         return p2
     where


### PR DESCRIPTION
This patch puts parens around SCC annotations per the 9.0 migration guide: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#parsing-of-scc-pragmas-less-permissive

Now this codebase builds with GHC 9: `cabal build reactive-banana -w ghc-9.0.1 --allow-newer=pqueue:base`