### PR TITLE
Change 'insertWith (flip (++))' to 'insertWith (++)' in 'insertEdge'

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Graph.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Graph.hs
@@ -30,8 +30,8 @@ emptyGraph = Graph Map.empty Map.empty Set.empty
 -- | Insert an edge from the first node to the second node into the graph.
 insertEdge :: (Eq a, Hashable a) => (a,a) -> Graph a -> Graph a
 insertEdge (x,y) gr = gr
-    { children = Map.insertWith (++) x [y] (children gr)
-    , parents  = Map.insertWith (++) y [x] (parents  gr)
+    { children = Map.insertWith (\new old -> new ++ old) x [y] (children gr)
+    , parents  = Map.insertWith (\new old -> new ++ old) y [x] (parents  gr)
     , nodes    = Set.insert x $ Set.insert y $ nodes gr
     }
 

--- a/reactive-banana/src/Reactive/Banana/Prim/Graph.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Graph.hs
@@ -30,8 +30,8 @@ emptyGraph = Graph Map.empty Map.empty Set.empty
 -- | Insert an edge from the first node to the second node into the graph.
 insertEdge :: (Eq a, Hashable a) => (a,a) -> Graph a -> Graph a
 insertEdge (x,y) gr = gr
-    { children = Map.insertWith (flip (++)) x [y] (children gr)
-    , parents  = Map.insertWith (flip (++)) y [x] (parents  gr)
+    { children = Map.insertWith (++) x [y] (children gr)
+    , parents  = Map.insertWith (++) y [x] (parents  gr)
     , nodes    = Set.insert x $ Set.insert y $ nodes gr
     }
 


### PR DESCRIPTION
`(++)` will put the new element at the head of the list, whereas `flip (++)` will put it at the end.

Was there a reason to keep the inserted edges in the order that they were inserted? If so, this patch reverses it. My assumption, based on the fact that it's a directed graph, is the order we store these lists is irrelevant.