### PR TITLE
Change links in reactive-banana.cabal  `source-repository` stanza

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -36,7 +36,7 @@ extra-doc-files:        doc/*.png
 
 Source-repository head
     type:               git
-    location:           git://github.com/HeinrichApfelmus/reactive-banana.git
+    location:           https://github.com/HeinrichApfelmus/reactive-banana
     subdir:             reactive-banana/
 
 Library


### PR DESCRIPTION
These links are shown on Hackage, and by using `http`, it's much easier for people to click them.