### PR TITLE
Change `Event` and `Behavior` to have a representational role

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Frameworks.hs
+++ b/reactive-banana/src/Reactive/Banana/Frameworks.hs
@@ -168,7 +168,7 @@ reactimate' = MIO . Prim.addReactimate . Prim.mapE unF . unE
 -- this will register a callback function such that
 -- an event will occur whenever the callback function is called.
 fromAddHandler ::AddHandler a -> MomentIO (Event a)
-fromAddHandler = MIO . fmap E . Prim.fromAddHandler
+fromAddHandler = MIO . fmap mkE . Prim.fromAddHandler
 
 -- | Input,
 -- obtain a 'Behavior' by frequently polling mutable data, like the current time.
@@ -183,7 +183,7 @@ fromAddHandler = MIO . fmap E . Prim.fromAddHandler
 -- it should not perform expensive computations.
 -- Neither should its side effects affect the event network significantly.
 fromPoll :: IO a -> MomentIO (Behavior a)
-fromPoll = MIO . fmap B . Prim.fromPoll
+fromPoll = MIO . fmap mkB . Prim.fromPoll
 
 -- | Input,
 -- obtain a 'Behavior' from an 'AddHandler' that notifies changes.
@@ -226,7 +226,7 @@ fromChanges initial changes = do
 -- this is indicated by the type 'Future'.
 -- It can be used only in the context of 'reactimate''.
 changes :: Behavior a -> MomentIO (Event (Future a))
-changes = return . E . Prim.mapE F . Prim.changesB . unB
+changes = return . mkE . Prim.mapE F . Prim.changesB . unB
 
 {- $changes
 
@@ -256,7 +256,7 @@ in this context. Still, it is useful in some cases.
 --
 -- Note: This function is useful only in very specific circumstances.
 imposeChanges :: Behavior a -> Event () -> Behavior a
-imposeChanges b e = B $ Prim.imposeChanges (unB b) (Prim.mapE (const ()) (unE e))
+imposeChanges b e = mkB $ Prim.imposeChanges (unB b) (Prim.mapE (const ()) (unE e))
 
 {- | Dynamically add input and output to an existing event network.
 
@@ -284,7 +284,7 @@ If your main goal is to reliably turn events into 'IO' actions,
 use the 'reactimate' and 'reactimate'' functions instead.
 -}
 execute :: Event (MomentIO a) -> MomentIO (Event a)
-execute = MIO . fmap E . Prim.executeE . Prim.mapE unMIO . unE
+execute = MIO . fmap mkE . Prim.executeE . Prim.mapE unMIO . unE
 
 -- $liftIO
 --

--- a/reactive-banana/src/Reactive/Banana/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Types.hs
@@ -1,13 +1,18 @@
+{-# language GADTs #-}
+{-# language RoleAnnotations #-}
+
 {-----------------------------------------------------------------------------
     reactive-banana
 ------------------------------------------------------------------------------}
 module Reactive.Banana.Types (
     -- | Primitive types.
-    Event(..), Behavior(..),
+    Event, mkE, unE,
+    Behavior, mkB, unB,
     Moment(..), MomentIO(..), MonadMoment(..),
     Future(..),
     ) where
 
+import Data.Bifunctor
 import Data.Semigroup
 import Control.Applicative
 import Control.Monad
@@ -33,8 +38,21 @@ no two event occurrences may happen at the same time.
 
 <<doc/frp-event.png>>
 -}
-newtype Event a = E { unE :: Prim.Event a }
+type role Event representational
+data Event a where
+  -- This strange definition allows us to make the @a@ parameter
+  -- @representational@ which allows users to use @coerce@ on @Event@.
+  E :: (x -> a) -> Prim.Event x -> Event a
 -- Invariant: The empty list `[]` never occurs as event value.
+
+
+unE :: Event a -> Prim.Event a
+unE (E out primEvent) = Prim.mapE out primEvent
+
+
+mkE :: Prim.Event a -> Event a
+mkE = E id
+
 
 -- | The function 'fmap' applies a function @f@ to every value.
 -- Semantically,
@@ -42,7 +60,7 @@ newtype Event a = E { unE :: Prim.Event a }
 -- > fmap :: (a -> b) -> Event a -> Event b
 -- > fmap f e = [(time, f a) | (time, a) <- e]
 instance Functor Event where
-    fmap f = E . Prim.mapE f . unE
+    fmap f = mkE . Prim.mapE f . unE
 
 -- | The combinator '<>' merges two event streams of the same type.
 -- In case of simultaneous occurrences,
@@ -52,7 +70,7 @@ instance Functor Event where
 -- > (<>) :: Event a -> Event a -> Event a
 -- > (<>) ex ey = unionWith (<>) ex ey
 instance Semigroup a => Semigroup (Event a) where
-    x <> y = E $ Prim.mergeWith Just Just (\a b -> Just (a <> b)) (unE x) (unE y)
+    x <> y = mkE $ Prim.mergeWith Just Just (\a b -> Just (a <> b)) (unE x) (unE y)
 
 -- | The combinator 'mempty' represents an event that never occurs.
 -- It is a synonym,
@@ -60,7 +78,7 @@ instance Semigroup a => Semigroup (Event a) where
 -- > mempty :: Event a
 -- > mempty = never
 instance Semigroup a => Monoid (Event a) where
-    mempty  = E $ Prim.never
+    mempty  = mkE $ Prim.never
     mappend = (<>)
 
 
@@ -71,7 +89,18 @@ Semantically, you can think of it as a function
 
 <<doc/frp-behavior.png>>
 -}
-newtype Behavior a = B { unB :: Prim.Behavior a }
+type role Behavior representational
+data Behavior a where
+  B :: (x -> a) -> Prim.Behavior x -> Behavior a
+
+
+mkB :: Prim.Behavior a -> Behavior a
+mkB = B id
+
+
+unB :: Behavior a -> Prim.Behavior a
+unB (B out primBehavior) = Prim.mapB out primBehavior
+
 
 -- | The function 'pure' returns a value that is constant in time. Semantically,
 --
@@ -83,8 +112,8 @@ newtype Behavior a = B { unB :: Prim.Behavior a }
 -- > (<*>)    :: Behavior (a -> b) -> Behavior a -> Behavior b
 -- > fx <*> bx = \time -> fx time $ bx time
 instance Applicative Behavior where
-    pure x    = B $ Prim.pureB x
-    bf <*> bx = B $ Prim.applyB (unB bf) (unB bx)
+    pure x    = mkB $ Prim.pureB x
+    bf <*> bx = mkB $ Prim.applyB (unB bf) (unB bx)
 
 -- | The function 'fmap' applies a function @f@ at every point in time.
 -- Semantically,


### PR DESCRIPTION
Fixes #219. The main problem is that in `newtype Event a = E (Prim.Event a)`, we have

```haskell
type Prim.Event a = Cached Moment (Pulse a)
data Cached m a = Cached (m a)
```

and that `Cached m a` definition forces `a` to be `nominal`.

This PR works around this nominal role by using a Coyoneda-trick, which restores the role to be representational (at the cost of carrying a mapping function around).