### PR TITLE
Generalise `newAddHandler` to any `MonadIO m`

### DIFF
--- a/reactive-banana/CHANGELOG.md
+++ b/reactive-banana/CHANGELOG.md
@@ -5,10 +5,12 @@ Changelog for the `reactive-banana** package
 
 * Add `merge` and `mergeWith` combinators. [#163][], [#220][]
 * Make internal SCC pragmas compatible with the GHC 9.0 parser. [#208][]
+* `newAddHandler` now works for any `MonadIO m`. [#225][]
 
   [#163]: https://github.com/HeinrichApfelmus/reactive-banana/pull/163
   [#208]: https://github.com/HeinrichApfelmus/reactive-banana/pull/208
   [#220]: https://github.com/HeinrichApfelmus/reactive-banana/pull/219
+  [#225]: https://github.com/HeinrichApfelmus/reactive-banana/pull/225
 
 **version 1.2.1.0**
 

--- a/reactive-banana/src/Control/Event/Handler.hs
+++ b/reactive-banana/src/Control/Event/Handler.hs
@@ -9,6 +9,7 @@ module Control.Event.Handler (
     ) where
 
 
+import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.IORef
 import qualified Data.Map    as Map
 import qualified Data.Unique
@@ -60,8 +61,8 @@ filterIO f e = AddHandler $ \h ->
 -- >     (addHandler, fire) <- newAddHandler
 -- >     register addHandler putStrLn
 -- >     fire "Hello!"
-newAddHandler :: IO (AddHandler a, Handler a)
-newAddHandler = do
+newAddHandler :: MonadIO m => m (AddHandler a, Handler a)
+newAddHandler = liftIO $ do
     handlers <- newIORef Map.empty
     let register handler = do
             key <- Data.Unique.newUnique


### PR DESCRIPTION
This makes it slightly more convenient to call when you're in other
monads (for example, `RIO`), saving the user a `liftIO`.