### PR TITLE
Add an `Eq (Ref a)` instance

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Types.hs
@@ -123,7 +123,6 @@ type Output  = Ref Output'
 data Output' = Output
     { _evalO     :: EvalP EvalO
     }
-instance Eq Output where (==) = equalRef
 
 data SomeNode
     = forall a. P (Pulse a)

--- a/reactive-banana/src/Reactive/Banana/Prim/Util.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Util.hs
@@ -28,6 +28,8 @@ nop = return ()
 ------------------------------------------------------------------------------}
 data Ref a = Ref !(IORef a) !Unique
 
+instance Eq (Ref a) where Ref _ x == Ref _ y = x == y
+
 instance Hashable (Ref a) where hashWithSalt s (Ref _ u) = hashWithSalt s u 
 
 equalRef :: Ref a -> Ref b -> Bool

--- a/reactive-banana/src/Reactive/Banana/Prim/Util.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Util.hs
@@ -28,7 +28,7 @@ nop = return ()
 ------------------------------------------------------------------------------}
 data Ref a = Ref !(IORef a) !Unique
 
-instance Eq (Ref a) where Ref _ x == Ref _ y = x == y
+instance Eq (Ref a) where (==) = equalRef
 
 instance Hashable (Ref a) where hashWithSalt s (Ref _ u) = hashWithSalt s u 
 


### PR DESCRIPTION
This is necessary as the latest version of the `hashable` package has `Eq a => Hashable a`.

The `Eq` instance has been added to match the `Hashable` instance.