### PR TITLE
Move tests to `tests/` and switch test runner to `tasty`

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -82,12 +82,12 @@ Library
 Test-Suite tests
     default-language:   Haskell98
     type:               exitcode-stdio-1.0
-    hs-source-dirs:     src
-    main-is:            Reactive/Banana/Test.hs
+    hs-source-dirs:     tests
+    main-is:            Main.hs
+    other-modules:      Plumbing
     build-depends:      base >= 4.2 && < 5,
-                        HUnit >= 1.2 && < 2,
-                        test-framework >= 0.6 && < 0.9,
-                        test-framework-hunit >= 0.2 && < 0.4,
+                        tasty,
+                        tasty-hunit,
                         reactive-banana, vault, containers,
                         semigroups, transformers,
                         unordered-containers, hashable, psqueues, pqueue, these

--- a/reactive-banana/tests/Main.hs
+++ b/reactive-banana/tests/Main.hs
@@ -8,19 +8,14 @@
 import Control.Arrow
 import Control.Monad (when, join)
 
-import Test.Framework (defaultMain, testGroup, Test)
-import Test.Framework.Providers.HUnit (testCase)
-
-import Test.HUnit (assert, Assertion)
-
--- import Test.QuickCheck
--- import Test.QuickCheck.Property
+import Test.Tasty (defaultMain, testGroup, TestTree)
+import Test.Tasty.HUnit (testCase, assertBool)
 
 import Control.Applicative
-import Reactive.Banana.Test.Plumbing
+import Plumbing
 
 
-main = defaultMain
+main = defaultMain $ testGroup "Tests"
     [ testGroup "Simple"
         [ testModelMatch "id"      id
         , testModelMatch "never1"  never1
@@ -82,8 +77,8 @@ singletons = map Just
 -- test whether model matches
 testModelMatchM
     :: (Show b, Eq b)
-    => String -> (Event Int -> Moment (Event b)) -> Test
-testModelMatchM name f = testCase name $ assert $ matchesModel f [1..8::Int]
+    => String -> (Event Int -> Moment (Event b)) -> TestTree
+testModelMatchM name f = testCase name $ assertBool "matchesModel" =<< matchesModel f [1..8::Int]
 testModelMatch name f = testModelMatchM name (return . f)
 
 -- individual tests for debugging

--- a/reactive-banana/tests/Plumbing.hs
+++ b/reactive-banana/tests/Plumbing.hs
@@ -4,14 +4,14 @@
 -- * Synopsis
 -- | Merge model and implementation into a single type. Not pretty.
 
-module Reactive.Banana.Test.Plumbing where
+module Plumbing where
 
 import Control.Applicative
 import Control.Monad (liftM, ap)
 import Control.Monad.Fix
 
 import qualified Reactive.Banana.Model as X
-import qualified Reactive.Banana.Internal.Combinators as Y
+import qualified Reactive.Banana as Y
 
 {-----------------------------------------------------------------------------
     Types as pairs
@@ -44,14 +44,14 @@ interpretGraph f = Y.interpret (fmap sndE . sndM . f . ey)
 never                               = E X.never Y.never
 filterJust (E x y)                  = E (X.filterJust x) (Y.filterJust y)
 mergeWith f g h (E x1 y1) (E x2 y2) = E (X.mergeWith f g h x1 x2) (Y.mergeWith f g h y1 y2)
-mapE f (E x y)                      = E (fmap f x) (Y.mapE f y)
-applyE ~(B x1 y1) (E x2 y2)         = E (X.apply x1 x2) (Y.applyE y1 y2)
+mapE f (E x y)                      = E (fmap f x) (fmap f y)
+applyE ~(B x1 y1) (E x2 y2)         = E (X.apply x1 x2) (y1 Y.<@> y2)
 
 instance Functor Event where fmap = mapE
 
-pureB a                         = B (pure a) (Y.pureB a)
-applyB (B x1 y1) (B x2 y2)      = B (x1 <*> x2) (Y.applyB y1 y2)
-mapB f (B x y)                  = B (fmap f x) (Y.mapB f y)
+pureB a                         = B (pure a) (pure a)
+applyB (B x1 y1) (B x2 y2)      = B (x1 <*> x2) (y1 <*> y2)
+mapB f (B x y)                  = B (fmap f x) (fmap f y)
 
 instance Functor     Behavior where fmap = mapB
 instance Applicative Behavior where pure = pureB; (<*>) = applyB
@@ -74,24 +74,24 @@ accumE   a ~(E x y) = M
     (ex <$> X.accumE a x)
     (ey <$> Y.accumE a y)
 stepperB a ~(E x y) = M
-    (bx <$> X.stepper  a x)
-    (by <$> Y.stepperB a y)
+    (bx <$> X.stepper a x)
+    (by <$> Y.stepper a y)
 stepper            = stepperB
 
 valueB ~(B x y) = M (X.valueB x) (Y.valueB y)
 
 observeE :: Event (Moment a) -> Event a
-observeE (E x y) = E (X.observeE $ fmap fstM x) (Y.observeE $ Y.mapE sndM y)
+observeE (E x y) = E (X.observeE $ fmap fstM x) (Y.observeE $ fmap sndM y)
 
 switchE :: Event (Event a) -> Moment (Event a)
 switchE (E x y) = M
-    (fmap ex $ X.switchE $   fmap fstE x)
-    (fmap ey $ Y.switchE $ Y.mapE sndE y)
+    (fmap ex $ X.switchE $ fmap fstE x)
+    (fmap ey $ Y.switchE $ fmap sndE y)
 
 switchB :: Behavior a -> Event (Behavior a) -> Moment (Behavior a)
 switchB (B x y) (E xe ye) = M
-    (fmap bx $ X.switchB x $   fmap fstB xe)
-    (fmap by $ Y.switchB y $ Y.mapE sndB ye)
+    (fmap bx $ X.switchB x $ fmap fstB xe)
+    (fmap by $ Y.switchB y $ fmap sndB ye)
 
 {-----------------------------------------------------------------------------
     Derived combinators


### PR DESCRIPTION
There are two changes going on here.

1. The existing tests were previously located in `src`, but they are now in `tests`. The reason for this is organizational, and the current layout confuses some tooling, such as `haskell-language-server` (`hls`). By having everything in one directory, `hls` thinks that the test modules are actually part of the library component, and fails to build as not all dependencies are available in this component. Furthermore, having everything in `src` means that even when we build the test suite, we end up rebuilding everything in `src` - even though we just built it for the library. There is occasionally a good reason to do this, and you can test private modules. We don't do this, so as far as I can tell, there's no benefit having everything in one directory.
2. I've changed the test runner to `tasty`. I think this is slightly more modern/supported/active than `test-framework`, and as of #234 we already have a dependency on `tasty` via `tasty-bench`. It seems sensible to minimize our dependency graph and move to `tasty`.