### PR TITLE
Build with `-O2`

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -78,7 +78,7 @@ Library
                         Reactive.Banana.Prim.Util,
                         Reactive.Banana.Types
     
-    ghc-options: -Wall -Wcompat -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-fields -Werror=partial-fields -Wno-name-shadowing
+    ghc-options: -O2 -Wall -Wcompat -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-fields -Werror=partial-fields -Wno-name-shadowing
 
 Test-Suite tests
     default-language:   Haskell98


### PR DESCRIPTION
The benchmarks speak for themselves here, I think!

First, with `-O0`:

```
$ cabal run benchmarks -O0
...
  netsize = 128
    ...
    duration = 128: OK (0.18s)
      13.1 ms ± 952 μs
```

Then, with `-O2`:

```
$ cabal run benchmarks -O2
...
  netsize = 128
    ...
    duration = 128: OK (0.20s)
      770  μs ±  47 μs
```

That is, the longest benchmark test goes from 13.1ms, down to 770μs - almost 20x faster.