### PR TITLE
Redefine `EventNetwork` to reduce allocations

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
@@ -1,7 +1,7 @@
 {-----------------------------------------------------------------------------
     reactive-banana
 ------------------------------------------------------------------------------}
-{-# LANGUAGE FlexibleInstances, NoMonomorphismRestriction #-}
+{-# LANGUAGE FlexibleInstances, NamedFieldPuns, NoMonomorphismRestriction #-}
 module Reactive.Banana.Internal.Combinators where
 
 import           Control.Concurrent.MVar
@@ -43,30 +43,35 @@ interpret f = Prim.interpret $ \pulse -> runReaderT (g pulse) undefined
 ------------------------------------------------------------------------------}
 -- | Data type representing an event network.
 data EventNetwork = EventNetwork
-    { runStep :: Prim.Step -> IO ()
-    , actuate :: IO ()
-    , pause   :: IO ()
+    { actuated :: IORef Bool
+    , s :: MVar Prim.Network
     }
+
+
+runStep :: EventNetwork -> Prim.Step -> IO ()
+runStep EventNetwork{ actuated, s } f = whenFlag actuated $ do
+    s1 <- takeMVar s                    -- read and take lock
+    -- pollValues <- sequence polls     -- poll mutable data
+    (output, s2) <- f s1                -- calculate new state
+    putMVar s s2                        -- write state
+    output                              -- run IO actions afterwards
+    where
+        whenFlag flag action = readIORef flag >>= \b -> when b action
+
+
+actuate :: EventNetwork -> IO ()
+actuate EventNetwork{ actuated } = writeIORef actuated True
+
+pause :: EventNetwork -> IO ()
+pause EventNetwork{ actuated } = writeIORef actuated False
 
 -- | Compile to an event network.
 compile :: Moment () -> IO EventNetwork
 compile setup = do
     actuated <- newIORef False                   -- flag to set running status
     s        <- newEmptyMVar                     -- setup callback machinery
-    let
-        whenFlag flag action = readIORef flag >>= \b -> when b action
-        runStep f            = whenFlag actuated $ do
-            s1 <- takeMVar s                    -- read and take lock
-            -- pollValues <- sequence polls     -- poll mutable data
-            (output, s2) <- f s1                -- calculate new state
-            putMVar s s2                        -- write state
-            output                              -- run IO actions afterwards
 
-        eventNetwork = EventNetwork
-            { runStep = runStep
-            , actuate = writeIORef actuated True
-            , pause   = writeIORef actuated False
-            }
+    let eventNetwork = EventNetwork{ actuated, s }
 
     (_output, s0) <-                             -- compile initial graph
         Prim.compile (runReaderT setup eventNetwork) Prim.emptyNetwork

--- a/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
@@ -55,8 +55,8 @@ runStep EventNetwork{ actuated, s } f = whenFlag actuated $ do
     (output, s2) <- f s1                -- calculate new state
     putMVar s s2                        -- write state
     output                              -- run IO actions afterwards
-    where
-        whenFlag flag action = readIORef flag >>= \b -> when b action
+  where
+    whenFlag flag action = readIORef flag >>= \b -> when b action
 
 
 actuate :: EventNetwork -> IO ()


### PR DESCRIPTION
The goal of this change is to reduce an allocation that occurs when firing the event network via with `fromAddHandler`. If we inspect the current STG, we see:

```haskell
Reactive.Banana.Internal.Combinators.$wfromAddHandler =
    \r [w_sydr w1_syds w2_sydt w3_sydu]
        case Reactive.Banana.Prim.IO.$wnewInput w2_sydt w3_sydu of {
        (#,#) ipv_sydw ipv1_sydx ->
        case ipv1_sydx of {
        (,) p_sydz fire_sydA ->
        let {
          sat_sydH :: Control.Event.Handler.Handler a_sx2k =
              \r [x_sydB]
                  case w1_syds of {
                  Reactive.Banana.Internal.Combinators.EventNetwork ds_sydD _ _ ->
                  let {
                    sat_sydG :: Reactive.Banana.Prim.Types.Step =
                        \u [] fire_sydA x_sydB;
                  } in  ds_sydD sat_sydG;
                  };
        } in
```

`sat_sydH` is the function that is used to `register` against the `AddHandler` to fire the network. If we look at this in more detail, we see that after pattern matching on an `EventNetwork`, we then allocate a `Step` to pass to `ds_sydD` - `ds_sydD` is the `runStep` function.

What we'd really like is to inline `runStep`, but because it's part of `EventNetwork`, this is very difficult. Fortunately, `runStep` can be lifted out to the top-level, and the free variables pulled out and moved into `EventNetwork`. This breaks a bit of encapsulation (though we could recover this with `module`).

The impact of this change is noticable. I first ran the benchmarks with `cabal run benchmarks -- --stdev 1 --csv baseline.csv`. Next, I applied the changes in this PR, and re-ran `cabal run benchmarks -- --stdev 1 --baseline baseline.csv`. The results are:

```
  netsize = 1
    duration = 1:   OK (0.94s)
      6.93 μs ± 133 ns
    duration = 2:   OK (1.78s)
      13.4 μs ± 213 ns,  3% faster than baseline
    duration = 4:   OK (7.10s)
      27.1 μs ± 210 ns,  1% faster than baseline
    duration = 8:   OK (7.08s)
      54.2 μs ± 613 ns,  1% faster than baseline
    duration = 16:  OK (1.77s)
      108  μs ± 1.8 μs
    duration = 32:  OK (0.87s)
      213  μs ± 3.5 μs,  4% faster than baseline
    duration = 64:  OK (3.54s)
      433  μs ± 5.5 μs
    duration = 128: OK (1.77s)
      865  μs ± 7.9 μs,  1% faster than baseline
  netsize = 2
    duration = 1:   OK (0.95s)
      7.15 μs ± 115 ns,  3% faster than baseline
    duration = 2:   OK (1.86s)
      14.1 μs ± 121 ns,  4% faster than baseline
    duration = 4:   OK (0.94s)
      28.3 μs ± 526 ns,  2% faster than baseline
    duration = 8:   OK (1.85s)
      55.9 μs ± 492 ns,  3% faster than baseline
    duration = 16:  OK (0.93s)
      113  μs ± 1.4 μs,  2% faster than baseline
    duration = 32:  OK (0.94s)
      226  μs ± 2.6 μs
    duration = 64:  OK (0.93s)
      450  μs ± 7.8 μs,  3% faster than baseline
    duration = 128: OK (0.93s)
      902  μs ±  15 μs,  1% faster than baseline
  netsize = 4
    duration = 1:   OK (3.86s)
      7.35 μs ±  57 ns,  1% faster than baseline
    duration = 2:   OK (1.91s)
      14.7 μs ± 275 ns
    duration = 4:   OK (0.96s)
      29.1 μs ± 386 ns
    duration = 8:   OK (0.96s)
      57.6 μs ± 940 ns,  2% faster than baseline
    duration = 16:  OK (3.79s)
      116  μs ± 983 ns,  1% faster than baseline
    duration = 32:  OK (3.77s)
      230  μs ± 2.2 μs,  2% faster than baseline
    duration = 64:  OK (1.88s)
      459  μs ± 6.2 μs
    duration = 128: OK (3.79s)
      922  μs ± 4.8 μs,  2% faster than baseline
  netsize = 8
    duration = 1:   OK (1.00s)
      7.72 μs ± 117 ns
    duration = 2:   OK (0.98s)
      15.0 μs ± 251 ns,  2% faster than baseline
    duration = 4:   OK (3.88s)
      29.5 μs ± 170 ns,  4% faster than baseline
    duration = 8:   OK (0.96s)
      58.1 μs ± 1.0 μs,  4% faster than baseline
    duration = 16:  OK (0.97s)
      117  μs ± 1.6 μs,  2% faster than baseline
    duration = 32:  OK (1.90s)
      231  μs ± 1.5 μs,  1% faster than baseline
    duration = 64:  OK (0.97s)
      468  μs ± 6.3 μs,  1% faster than baseline
    duration = 128: OK (0.96s)
      934  μs ±  14 μs,  1% faster than baseline
  netsize = 16
    duration = 1:   OK (2.16s)
      8.18 μs ± 130 ns
    duration = 2:   OK (2.05s)
      15.6 μs ± 123 ns,  2% faster than baseline
    duration = 4:   OK (4.02s)
      30.5 μs ± 247 ns,  4% faster than baseline
    duration = 8:   OK (1.98s)
      60.3 μs ± 942 ns,  2% faster than baseline
    duration = 16:  OK (1.96s)
      119  μs ± 1.6 μs,  3% faster than baseline
    duration = 32:  OK (0.97s)
      234  μs ± 4.3 μs,  4% faster than baseline
    duration = 64:  OK (0.97s)
      467  μs ± 8.4 μs,  5% faster than baseline
    duration = 128: OK (3.91s)
      953  μs ±  13 μs,  3% faster than baseline
  netsize = 32
    duration = 1:   OK (2.41s)
      9.22 μs ±  59 ns,  1% faster than baseline
    duration = 2:   OK (8.93s)
      17.0 μs ±  59 ns,  1% faster than baseline
    duration = 4:   OK (1.07s)
      32.1 μs ± 411 ns,  4% faster than baseline
    duration = 8:   OK (1.03s)
      62.9 μs ± 1.0 μs,  3% faster than baseline
    duration = 16:  OK (1.03s)
      125  μs ± 2.0 μs,  1% faster than baseline
    duration = 32:  OK (1.01s)
      243  μs ± 4.6 μs,  3% faster than baseline
    duration = 64:  OK (4.06s)
      493  μs ± 8.2 μs,  2% faster than baseline
    duration = 128: OK (8.09s)
      983  μs ±  12 μs,  2% faster than baseline
  netsize = 64
    duration = 1:   OK (1.50s)
      11.3 μs ± 175 ns,  2% faster than baseline
    duration = 2:   OK (1.26s)
      19.2 μs ± 265 ns,  4% faster than baseline
    duration = 4:   OK (1.19s)
      35.9 μs ± 676 ns
    duration = 8:   OK (2.19s)
      66.4 μs ± 751 ns,  3% faster than baseline
    duration = 16:  OK (2.18s)
      133  μs ± 1.1 μs,  2% faster than baseline
    duration = 32:  OK (4.30s)
      261  μs ± 1.3 μs
    duration = 64:  OK (1.08s)
      521  μs ± 9.3 μs
    duration = 128: OK (4.22s)
      1.03 ms ±  13 μs,  2% faster than baseline
  netsize = 128
    duration = 1:   OK (8.43s)
      16.1 μs ± 108 ns,  1% faster than baseline
    duration = 2:   OK (1.64s)
      25.1 μs ± 192 ns,  1% faster than baseline
    duration = 4:   OK (1.37s)
      41.4 μs ± 542 ns,  4% faster than baseline
    duration = 8:   OK (5.02s)
      76.6 μs ± 918 ns,  1% faster than baseline
    duration = 16:  OK (0.60s)
      144  μs ± 2.9 μs,  3% faster than baseline
    duration = 32:  OK (1.14s)
      277  μs ± 3.1 μs,  4% faster than baseline
    duration = 64:  OK (2.46s)
      598  μs ± 4.6 μs,  4% slower than baseline
    duration = 128: OK (0.61s)
      1.20 ms ±  22 μs,  4% slower than baseline
  Boring:           OK (14.40s)
    232  ms ± 1.5 ms, 29% faster than baseline
```

The most striking difference is "Boring". This is a "no-op" benchmark, which is now 30% faster (!), and also apparently allocates 0 bytes (though I don't entirely believe this, I think it's measurement error).