### PR TITLE
Remove references to old test files.

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -28,9 +28,7 @@ Build-type:          Simple
 Tested-with:         GHC == 8.4.3, GHC == 8.6.1
 
 extra-source-files:     CHANGELOG.md,
-                        doc/examples/*.hs,
-                        src/Reactive/Banana/Test.hs,
-                        src/Reactive/Banana/Test/Plumbing.hs
+                        doc/examples/*.hs
 extra-doc-files:        doc/*.png
 
 Source-repository head


### PR DESCRIPTION
It seems that when @ocharles moved the test files to their own directory (#235), they forgot to remove references to those files in the extra-source-files field of the cabal file. This leads to an error when trying to use Reactive Banana as a `source-repository-package` in a cabal.project, as cabal while complain that such files do not exist.