### PR TITLE
Add first draft of design document + rearrange modules

### DIFF
--- a/reactive-banana/doc/design/design.md
+++ b/reactive-banana/doc/design/design.md
@@ -1,0 +1,77 @@
+# Design and Implementation of the reactive-banana FRP library
+
+by Heinrich Apfelmus
+
+licensed CC-BY-SA 4.0
+
+DRAFT, INCOMPLETE
+
+This document is intended to describe the design and implementation of the reactive-banana library for functional reactive programming (FRP).
+
+NOTE: This draft text already uses the plural `Events` as opposed to the singular `Event` for the data type.
+
+## Introduction
+
+Functional reactive programming (FRP) is a programming paradigm for declarative programming with data that changes over time. It was introduced in the seminal paper [Elliot and Hudak (1997)][fran] with two concepts, *Behavior* and *Events*. A *Behavior* denotes a value that varies in time, i.e. *Behavior* is a data type that represents the entire history and future of a value. *Events* denote a sequence of discrete moments in time which carry additional data.
+
+For example, consider a graphical user interface (GUI) with a button and a numerical display whose value tracks the number of times that the button has been pressed. This value changes over time and can be represented as a *Behavior*. The clicks on the button are represented as *Events*; specifically, we have a variable of type `Events ()` that represents all future (!) clicks. The purpose of our program is to specify how these button `Events ()` are translated into a counter `Behavior Int` in a declarative manner. Of course, it is not possible to know all future clicks and write them into computer memory in advance, but it is useful to *pretend* to know them in advance, and to write a declarative program with that. As long as this program does not peek into the future, i.e. as long as it does not violate causality, it can be executed. The purpose of the reactive-banana FRP library is to execute such programs.
+
+  [fran]: http://conal.net/papers/icfp97/
+
+[…]
+
+## Semantics
+
+* Behavior uses **continuous time**. There is no notion of "update" for a Behavior. (For reasons of efficiency, the implementation does keep track of updates, though.) The advantage of this design is that it is not possible to write programs that depend on how often a Behavior updates, especially for updates that do not actually change the value.
+
+* **Recursion** is allowed (and necessary). Specifically, all mututal recursions between Behavior and Event are well-defined.
+
+[…]
+
+## Implementation
+
+### Time leaks and Updates
+
+The easiest way to implement Events would be as a list of values tagged with their time of occurrence, e.g.
+
+    type Events a = [(Time, a)]
+
+By using a list lazy, future events which are not yet known can be added to the list when they occur.
+
+However, any representation of Events as a pure data structure is problematic: As long as a variable `x :: Events A` is in scope, purity of the data structure implies that all events that have ever occurred will be kept alive as long as the variable `x` is alive. This is known as a **time leak**: Past events are stored and have to be traversed (repeatedly even) in order to reach the present moment. In order to be efficient, we have to discard old events which are no longer relevant, and this implies that the `Events` data structure needs to support impure updates. Note that lazy lists already use impure updates through their laziness, though these are transparent at the language level. Also, the problem of time leaks becomes apparent mostly in the presence of dynamic event switching, when the first-class nature of `Events` is used extensively.
+
+### Push- versus pull
+
+[…]
+
+The necessity of implementing `Events` as a data structure that supports updates is challenging. We split the problem into several parts:
+
+1. *Low-level*. We implement a mutable graph which represents dependencies between Events and allows us to implement push-based propagation of information.
+
+2. *Mid-level*. We define low-level data structure `Pulse` and `Latch` that roughly correspond to Events and Behavior, but which are essentially just references to nodes in the mutable graph above. New nodes can be created with monadic functions such as
+
+        union :: Pluse a -> Pulse a -> Build (Pulse a)
+
+    where `Build` is a monad that describes changes to the mutable graph.
+
+3. *High-level*. We implement *Event* and *Behavior* in terms of `Pulse` and `Latch`. Here, we use **observable sharing** to map Haskell variables to mutable references, and to turn impure functions into pure functions where possible.
+
+### Low-level: Mutable graph
+
+* The difficulty of `union` in a push-based setting: Dependency order, priorities.
+* `Vault` for storage.
+* Garbage collection
+
+[…]
+
+### Mid-level: Pulse and Latch
+
+* `Build` monad.
+
+[…]
+
+### High-level: Events and Behavior
+
+* Caching / observable sharing.
+
+[…]

--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -56,24 +56,24 @@ Library
                         Reactive.Banana.Combinators,
                         Reactive.Banana.Frameworks,
                         Reactive.Banana.Model,
-                        Reactive.Banana.Prim,
-                        Reactive.Banana.Prim.Cached
+                        Reactive.Banana.Prim.Mid,
+                        Reactive.Banana.Prim.High.Cached
 
     other-modules:
                         Control.Monad.Trans.ReaderWriterIO,
                         Control.Monad.Trans.RWSIO,
-                        Reactive.Banana.Internal.Combinators,
-                        Reactive.Banana.Prim.Combinators,
-                        Reactive.Banana.Prim.Compile,
-                        Reactive.Banana.Prim.Dependencies,
-                        Reactive.Banana.Prim.Evaluation,
-                        Reactive.Banana.Prim.Graph,
-                        Reactive.Banana.Prim.IO,
-                        Reactive.Banana.Prim.OrderedBag,
-                        Reactive.Banana.Prim.Plumbing,
-                        Reactive.Banana.Prim.Test,
-                        Reactive.Banana.Prim.Types,
-                        Reactive.Banana.Prim.Util,
+                        Reactive.Banana.Prim.Low.Compile,
+                        Reactive.Banana.Prim.Low.Dependencies,
+                        Reactive.Banana.Prim.Low.Evaluation,
+                        Reactive.Banana.Prim.Low.Graph,
+                        Reactive.Banana.Prim.Low.IO,
+                        Reactive.Banana.Prim.Low.OrderedBag,
+                        Reactive.Banana.Prim.Low.Plumbing,
+                        Reactive.Banana.Prim.Low.Types,
+                        Reactive.Banana.Prim.Low.Util,
+                        Reactive.Banana.Prim.Mid.Combinators,
+                        Reactive.Banana.Prim.Mid.Test,
+                        Reactive.Banana.Prim.High.Combinators,
                         Reactive.Banana.Types
     
     ghc-options: -Wall -Wcompat -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-fields -Werror=partial-fields -Wno-name-shadowing

--- a/reactive-banana/src/Reactive/Banana/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Combinators.hs
@@ -49,7 +49,7 @@ import Control.Applicative
 import Data.Semigroup
 import Data.These (These(..))
 
-import qualified Reactive.Banana.Internal.Combinators as Prim
+import qualified Reactive.Banana.Prim.High.Combinators as Prim
 import           Reactive.Banana.Types
 
 {-----------------------------------------------------------------------------

--- a/reactive-banana/src/Reactive/Banana/Frameworks.hs
+++ b/reactive-banana/src/Reactive/Banana/Frameworks.hs
@@ -42,7 +42,7 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.IORef
 import           Reactive.Banana.Combinators
-import qualified Reactive.Banana.Internal.Combinators as Prim
+import qualified Reactive.Banana.Prim.High.Combinators as Prim
 import           Reactive.Banana.Types
 
 

--- a/reactive-banana/src/Reactive/Banana/Prim/High/Cached.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/High/Cached.hs
@@ -2,7 +2,7 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE RecursiveDo #-}
-module Reactive.Banana.Prim.Cached (
+module Reactive.Banana.Prim.High.Cached (
     -- | Utility for executing monadic actions once
     -- and then retrieving values from a cache.
     --

--- a/reactive-banana/src/Reactive/Banana/Prim/High/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/High/Combinators.hs
@@ -2,7 +2,7 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE FlexibleInstances, NamedFieldPuns, NoMonomorphismRestriction #-}
-module Reactive.Banana.Internal.Combinators where
+module Reactive.Banana.Prim.High.Combinators where
 
 import           Control.Concurrent.MVar
 import           Control.Event.Handler
@@ -11,8 +11,8 @@ import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class           (lift)
 import           Control.Monad.Trans.Reader
 import           Data.IORef
-import qualified Reactive.Banana.Prim        as Prim
-import           Reactive.Banana.Prim.Cached
+import qualified Reactive.Banana.Prim.Mid        as Prim
+import           Reactive.Banana.Prim.High.Cached
 
 type Build   = Prim.Build
 type Latch a = Prim.Latch a

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Compile.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Compile.hs
@@ -3,17 +3,17 @@
 ------------------------------------------------------------------------------}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
-module Reactive.Banana.Prim.Compile where
+module Reactive.Banana.Prim.Low.Compile where
 
 import Control.Exception (evaluate)
 import Data.Functor
 import Data.IORef
 
-import           Reactive.Banana.Prim.Combinators
-import           Reactive.Banana.Prim.IO
-import qualified Reactive.Banana.Prim.OrderedBag  as OB
-import           Reactive.Banana.Prim.Plumbing
-import           Reactive.Banana.Prim.Types
+import           Reactive.Banana.Prim.Mid.Combinators (mapP)
+import           Reactive.Banana.Prim.Low.IO
+import qualified Reactive.Banana.Prim.Low.OrderedBag  as OB
+import           Reactive.Banana.Prim.Low.Plumbing
+import           Reactive.Banana.Prim.Low.Types
 
 {-----------------------------------------------------------------------------
    Compilation

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Dependencies.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Dependencies.hs
@@ -3,7 +3,7 @@
 ------------------------------------------------------------------------------}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE LambdaCase #-}
-module Reactive.Banana.Prim.Dependencies (
+module Reactive.Banana.Prim.Low.Dependencies (
     -- | Utilities for operating on node dependencies.
     addChild, changeParent, buildDependencies,
     ) where
@@ -12,9 +12,9 @@ import           Control.Monad
 import           Data.Monoid
 import           System.Mem.Weak
 
-import qualified Reactive.Banana.Prim.Graph as Graph
-import           Reactive.Banana.Prim.Types
-import           Reactive.Banana.Prim.Util
+import qualified Reactive.Banana.Prim.Low.Graph as Graph
+import           Reactive.Banana.Prim.Low.Types
+import           Reactive.Banana.Prim.Low.Util
 
 {-----------------------------------------------------------------------------
     Accumulate dependency information for nodes

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Evaluation.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Evaluation.hs
@@ -2,7 +2,7 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE RecordWildCards #-}
-module Reactive.Banana.Prim.Evaluation (
+module Reactive.Banana.Prim.Low.Evaluation (
     step
     ) where
 
@@ -13,10 +13,10 @@ import qualified Data.PQueue.Prio.Min               as Q
 import qualified Data.Vault.Lazy                    as Lazy
 import           System.Mem.Weak
 
-import qualified Reactive.Banana.Prim.OrderedBag as OB
-import           Reactive.Banana.Prim.Plumbing
-import           Reactive.Banana.Prim.Types
-import           Reactive.Banana.Prim.Util
+import qualified Reactive.Banana.Prim.Low.OrderedBag as OB
+import           Reactive.Banana.Prim.Low.Plumbing
+import           Reactive.Banana.Prim.Low.Types
+import           Reactive.Banana.Prim.Low.Util
 
 type Queue = Q.MinPQueue Level
 

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Graph.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Graph.hs
@@ -5,7 +5,7 @@
 ------------------------------------------------------------------------------}
 {-# language ScopedTypeVariables#-}
 
-module Reactive.Banana.Prim.Graph
+module Reactive.Banana.Prim.Low.Graph
   ( Graph
   , emptyGraph
   , insertEdge

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/IO.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/IO.hs
@@ -3,16 +3,16 @@
 ------------------------------------------------------------------------------}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Reactive.Banana.Prim.IO where
+module Reactive.Banana.Prim.Low.IO where
 
 import           Control.Monad.IO.Class
 import qualified Data.Vault.Lazy        as Lazy
 
-import Reactive.Banana.Prim.Combinators (mapP)
-import Reactive.Banana.Prim.Evaluation  (step)
-import Reactive.Banana.Prim.Plumbing
-import Reactive.Banana.Prim.Types
-import Reactive.Banana.Prim.Util
+import Reactive.Banana.Prim.Mid.Combinators (mapP)
+import Reactive.Banana.Prim.Low.Evaluation  (step)
+import Reactive.Banana.Prim.Low.Plumbing
+import Reactive.Banana.Prim.Low.Types
+import Reactive.Banana.Prim.Low.Util
 
 debug :: String -> a -> a
 debug _ = id

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/OrderedBag.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/OrderedBag.hs
@@ -4,7 +4,7 @@
     Implementation of a bag whose elements are ordered by arrival time.
 ------------------------------------------------------------------------------}
 {-# LANGUAGE TupleSections #-}
-module Reactive.Banana.Prim.OrderedBag where
+module Reactive.Banana.Prim.Low.OrderedBag where
 
 import qualified Data.HashMap.Strict as Map
 import           Data.Hashable

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Plumbing.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Plumbing.hs
@@ -2,7 +2,7 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE RecordWildCards, RecursiveDo, ScopedTypeVariables #-}
-module Reactive.Banana.Prim.Plumbing where
+module Reactive.Banana.Prim.Low.Plumbing where
 
 import           Control.Monad                                (join)
 import           Control.Monad.IO.Class
@@ -13,9 +13,9 @@ import           Data.IORef
 import qualified Data.Vault.Lazy                    as Lazy
 import           System.IO.Unsafe
 
-import qualified Reactive.Banana.Prim.Dependencies as Deps
-import           Reactive.Banana.Prim.Types
-import           Reactive.Banana.Prim.Util
+import qualified Reactive.Banana.Prim.Low.Dependencies as Deps
+import           Reactive.Banana.Prim.Low.Types
+import           Reactive.Banana.Prim.Low.Util
 import Data.Maybe (fromMaybe)
 
 {-----------------------------------------------------------------------------

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Types.hs
@@ -3,7 +3,7 @@
 ------------------------------------------------------------------------------}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
-module Reactive.Banana.Prim.Types where
+module Reactive.Banana.Prim.Low.Types where
 
 import           Control.Monad.Trans.RWSIO
 import           Control.Monad.Trans.ReaderWriterIO
@@ -13,9 +13,9 @@ import qualified Data.Vault.Lazy                    as Lazy
 import           System.IO.Unsafe
 import           System.Mem.Weak
 
-import Reactive.Banana.Prim.Graph            (Graph)
-import Reactive.Banana.Prim.OrderedBag as OB (OrderedBag)
-import Reactive.Banana.Prim.Util
+import Reactive.Banana.Prim.Low.Graph            (Graph)
+import Reactive.Banana.Prim.Low.OrderedBag as OB (OrderedBag)
+import Reactive.Banana.Prim.Low.Util
 
 {-----------------------------------------------------------------------------
     Network

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Util.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Util.hs
@@ -2,7 +2,7 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE MagicHash, UnboxedTuples #-}
-module Reactive.Banana.Prim.Util where
+module Reactive.Banana.Prim.Low.Util where
 
 import           Control.Monad
 import           Control.Monad.IO.Class

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid.hs
@@ -1,7 +1,7 @@
 {-----------------------------------------------------------------------------
     reactive-banana
 ------------------------------------------------------------------------------}
-module Reactive.Banana.Prim (
+module Reactive.Banana.Prim.Mid (
     -- * Synopsis
     -- | This is an internal module, useful if you want to
     -- implemented your own FRP library.
@@ -16,7 +16,7 @@ module Reactive.Banana.Prim (
     module Control.Monad.IO.Class,
 
     -- * Caching
-    module Reactive.Banana.Prim.Cached,
+    module Reactive.Banana.Prim.High.Cached,
 
     -- * Testing
     interpret, mapAccumM, mapAccumM_, runSpaceProfile,
@@ -41,12 +41,13 @@ module Reactive.Banana.Prim (
 
 
 import Control.Monad.IO.Class
-import Reactive.Banana.Prim.Cached
-import Reactive.Banana.Prim.Combinators
-import Reactive.Banana.Prim.Compile
-import Reactive.Banana.Prim.IO
-import Reactive.Banana.Prim.Plumbing (neverP, alwaysP, liftBuild, buildLater, buildLaterReadNow, liftIOLater)
-import Reactive.Banana.Prim.Types
+import Reactive.Banana.Prim.Low.Compile
+import Reactive.Banana.Prim.Low.IO
+import Reactive.Banana.Prim.Low.Plumbing
+    ( neverP, alwaysP, liftBuild, buildLater, buildLaterReadNow, liftIOLater )
+import Reactive.Banana.Prim.Low.Types
+import Reactive.Banana.Prim.Mid.Combinators
+import Reactive.Banana.Prim.High.Cached
 
 {-----------------------------------------------------------------------------
     Notes

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Combinators.hs
@@ -2,19 +2,19 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE RecursiveDo, ScopedTypeVariables #-}
-module Reactive.Banana.Prim.Combinators where
+module Reactive.Banana.Prim.Mid.Combinators where
 
 import Control.Monad
 import Control.Monad.IO.Class
 
-import Reactive.Banana.Prim.Plumbing
+import Reactive.Banana.Prim.Low.Plumbing
     ( newPulse, newLatch, cachedLatch
     , dependOn, keepAlive, changeParent
     , getValueL
     , readPulseP, readLatchP, readLatchFutureP, liftBuildP,
     )
-import qualified Reactive.Banana.Prim.Plumbing (pureL)
-import           Reactive.Banana.Prim.Types    (Latch, Future, Pulse, Build, EvalP)
+import qualified Reactive.Banana.Prim.Low.Plumbing (pureL)
+import           Reactive.Banana.Prim.Low.Types    (Latch, Future, Pulse, Build, EvalP)
 
 debug :: String -> a -> a
 -- debug s = trace s
@@ -85,7 +85,7 @@ applyP f x = do
     return p
 
 pureL :: a -> Latch a
-pureL = Reactive.Banana.Prim.Plumbing.pureL
+pureL = Reactive.Banana.Prim.Low.Plumbing.pureL
 
 -- specialization of   mapL f = applyL (pureL f)
 mapL :: (a -> b) -> Latch a -> Latch b

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Test.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Test.hs
@@ -2,9 +2,9 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE RecursiveDo #-}
-module Reactive.Banana.Prim.Test where
+module Reactive.Banana.Prim.Mid.Test where
 
-import Reactive.Banana.Prim
+import Reactive.Banana.Prim.Mid
 
 main :: IO ()
 main = test_space1

--- a/reactive-banana/src/Reactive/Banana/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Types.hs
@@ -13,7 +13,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Fix
 import Data.String (IsString(..))
 
-import qualified Reactive.Banana.Internal.Combinators as Prim
+import qualified Reactive.Banana.Prim.High.Combinators as Prim
 
 {-----------------------------------------------------------------------------
     Types


### PR DESCRIPTION
I have begun writing a draft on the design internals of the reactive-banana library. I had always wanted to write this up, as I believe that there are a couple of intricate design issues solved, but have never found the time to do so — until now.

Documenting the internals is useful for understanding and fixing issues such as #228 .

I have also rearranged the modules to follow the "design levels" (low, mid, high) in an attempt to make the edifice easier to understand. The idea is that understanding the implementation of a lower level is not required for understanding the implementation of a higher level.

Question to my dear co-maintainers: As writing will still be slow in the foreseeable future, which areas in the `design.md` document would you like me to expand on next? Anything that you are particularly interested in or find particularly puzzling?