### PR TITLE
Make Network always contain the always-pulse

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Internal/Combinators.hs
@@ -74,7 +74,7 @@ compile setup = do
     let eventNetwork = EventNetwork{ actuated, s }
 
     (_output, s0) <-                             -- compile initial graph
-        Prim.compile (runReaderT setup eventNetwork) Prim.emptyNetwork
+        Prim.compile (runReaderT setup eventNetwork) =<< Prim.emptyNetwork
     putMVar s s0                                -- set initial state
 
     return eventNetwork

--- a/reactive-banana/src/Reactive/Banana/Prim/Compile.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Compile.hs
@@ -21,7 +21,7 @@ import           Reactive.Banana.Prim.Types
 -- | Change a 'Network' of pulses and latches by
 -- executing a 'BuildIO' action.
 compile :: BuildIO a -> Network -> IO (a, Network)
-compile m Network {nTime, nOutputs, nAlwaysP} = do
+compile m Network{nTime, nOutputs, nAlwaysP} = do
     (a, topology, os) <- runBuildIO (nTime, nAlwaysP) m
     doit topology
 

--- a/reactive-banana/src/Reactive/Banana/Prim/Compile.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Compile.hs
@@ -2,6 +2,7 @@
     reactive-banana
 ------------------------------------------------------------------------------}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
 module Reactive.Banana.Prim.Compile where
 
 import Control.Exception (evaluate)
@@ -20,14 +21,14 @@ import           Reactive.Banana.Prim.Types
 -- | Change a 'Network' of pulses and latches by
 -- executing a 'BuildIO' action.
 compile :: BuildIO a -> Network -> IO (a, Network)
-compile m (Network time1 outputs1 theAlwaysP) = do
-    (a, topology, os) <- runBuildIO (time1, theAlwaysP) m
+compile m Network {nTime, nOutputs, nAlwaysP} = do
+    (a, topology, os) <- runBuildIO (nTime, nAlwaysP) m
     doit topology
 
     let state2 = Network
-            { nTime    = next time1
-            , nOutputs = OB.inserts outputs1 os
-            , nAlwaysP = theAlwaysP
+            { nTime    = next nTime
+            , nOutputs = OB.inserts nOutputs os
+            , nAlwaysP
             }
     return (a,state2)
 

--- a/reactive-banana/src/Reactive/Banana/Prim/Compile.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Compile.hs
@@ -20,25 +20,25 @@ import           Reactive.Banana.Prim.Types
 -- | Change a 'Network' of pulses and latches by
 -- executing a 'BuildIO' action.
 compile :: BuildIO a -> Network -> IO (a, Network)
-compile m state1 = do
-    let time1    = nTime state1
-        outputs1 = nOutputs state1
-
-    theAlwaysP <- case nAlwaysP state1 of
-        Just x   -> return x
-        Nothing  -> do
-            (x,_,_) <- runBuildIO undefined $ newPulse "alwaysP" (return $ Just ())
-            return x
-
-    (a, topology, os) <- runBuildIO (nTime state1, theAlwaysP) m
+compile m (Network time1 outputs1 theAlwaysP) = do
+    (a, topology, os) <- runBuildIO (time1, theAlwaysP) m
     doit topology
 
     let state2 = Network
             { nTime    = next time1
             , nOutputs = OB.inserts outputs1 os
-            , nAlwaysP = Just theAlwaysP
+            , nAlwaysP = theAlwaysP
             }
     return (a,state2)
+
+emptyNetwork :: IO Network
+emptyNetwork = do
+  (alwaysP, _, _) <- runBuildIO undefined $ newPulse "alwaysP" (return $ Just ())
+  pure Network
+    { nTime    = next beginning
+    , nOutputs = OB.empty
+    , nAlwaysP = alwaysP
+    }
 
 {-----------------------------------------------------------------------------
     Testing
@@ -60,7 +60,7 @@ interpret f xs = do
             return sin
 
     -- compile initial network
-    (sin, state) <- compile network emptyNetwork
+    (sin, state) <- compile network =<< emptyNetwork
 
     let go Nothing  s1 = return (Nothing,s1)
         go (Just a) s1 = do
@@ -84,7 +84,7 @@ runSpaceProfile f xs = do
         p3 <- mapP return p2                -- wrap into Future
         addHandler p3 (void . evaluate)
         return fire
-    (step,network) <- compile g emptyNetwork
+    (step,network) <- compile g =<< emptyNetwork
 
     let fire x s1 = do
             (outputs, s2) <- step x s1

--- a/reactive-banana/src/Reactive/Banana/Prim/Evaluation.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Evaluation.hs
@@ -29,7 +29,7 @@ step :: Inputs -> Step
 step (inputs,pulses)
         Network{ nTime = time1
         , nOutputs = outputs1
-        , nAlwaysP = Just alwaysP   -- we assume that this has been built already
+        , nAlwaysP = alwaysP
         }
     = do
 
@@ -48,10 +48,9 @@ step (inputs,pulses)
         state2  = Network
             { nTime    = next time1
             , nOutputs = OB.inserts outputs1 os
-            , nAlwaysP = Just alwaysP
+            , nAlwaysP = alwaysP
             }
     return (runEvalOs $ map snd actions, state2)
-step _ Network{ nAlwaysP = Nothing } = error "step: step called when nAlwaysP is Nothing"
 
 runEvalOs :: [EvalO] -> IO ()
 runEvalOs = mapM_ join

--- a/reactive-banana/src/Reactive/Banana/Prim/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Types.hs
@@ -14,7 +14,7 @@ import           System.IO.Unsafe
 import           System.Mem.Weak
 
 import Reactive.Banana.Prim.Graph            (Graph)
-import Reactive.Banana.Prim.OrderedBag as OB (OrderedBag, empty)
+import Reactive.Banana.Prim.OrderedBag as OB (OrderedBag)
 import Reactive.Banana.Prim.Util
 
 {-----------------------------------------------------------------------------
@@ -24,19 +24,12 @@ import Reactive.Banana.Prim.Util
 data Network = Network
     { nTime           :: !Time                 -- Current time.
     , nOutputs        :: !(OrderedBag Output)  -- Remember outputs to prevent garbage collection.
-    , nAlwaysP        :: !(Maybe (Pulse ()))   -- Pulse that always fires.
+    , nAlwaysP        :: !(Pulse ())   -- Pulse that always fires.
     }
 
 type Inputs        = ([SomeNode], Lazy.Vault)
 type EvalNetwork a = Network -> IO (a, Network)
 type Step          = EvalNetwork (IO ())
-
-emptyNetwork :: Network
-emptyNetwork = Network
-    { nTime    = next beginning
-    , nOutputs = OB.empty
-    , nAlwaysP = Nothing
-    }
 
 type Build  = ReaderWriterIOT BuildR BuildW IO
 type BuildR = (Time, Pulse ())


### PR DESCRIPTION
This PR replaces the

```haskell
nAlwaysP :: Maybe (Pulse ())
```

field of `Network` with

```haskell
nAlwaysP :: Pulse ()
```

and propagates that change around the codebase.

Previously, when compiling a network, we checked to see whether it had an always-pulse, and built it if not.

In this PR, we instead just create the always-pulse when initializing an empty network in IO.