### PR TITLE
Fix space leak in dynamic event switching

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Dependencies.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Dependencies.hs
@@ -48,7 +48,7 @@ connectChild
     -> IO (Weak SomeNode)
                 -- ^ Weak reference with the child as key and the parent as value.
 connectChild parent child = do
-    w <- mkWeakNodeValue child child
+    w <- someNodeRef child
     modify' parent $ update childrenP (w:)
     mkWeakNodeValue child (P parent)        -- child keeps parent alive
 

--- a/reactive-banana/src/Reactive/Banana/Prim/Low/IO.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/IO.hs
@@ -28,15 +28,19 @@ newInput :: forall a. Build (Pulse a, a -> Step)
 newInput = mdo
     always <- alwaysP
     key    <- liftIO Lazy.newKey
-    pulse  <- liftIO $ newRef $ Pulse
-        { _keyP      = key
-        , _seenP     = agesAgo
-        , _evalP     = readPulseP pulse    -- get its own value
-        , _childrenP = []
-        , _parentsP  = []
-        , _levelP    = ground
-        , _nameP     = "newInput"
-        }
+    pulse  <- liftIO $ mdo
+        me <- newRef $ Pulse
+            { _keyP      = key
+            , _seenP     = agesAgo
+            , _evalP     = readPulseP pulse    -- get its own value
+            , _childrenP = []
+            , _parentsP  = []
+            , _levelP    = ground
+            , _nameP     = "newInput"
+            , _pulsePtr  = w
+            }
+        w <- mkWeakRefValue me (P me)
+        return me
     -- Also add the  alwaysP  pulse to the inputs.
     let run :: a -> Step
         run a = step ([P pulse, P always], Lazy.insert key (Just a) Lazy.empty)


### PR DESCRIPTION
Currently we have a nasty space leak in dynamic event switching. The crux of the problem is that we have a child event that needs to have a new parent. When we change the parent of a node, we need to create a weak pointer to the new parent and store it in the child's list of parents, and we need to store a weak pointer to the child in the new parent node.

Currently `connectChild` does this by creating a new weak pointer to the child whenever the parent changes:

```haskell
w <- mkWeakNodeValue child child
```

Here we create a weak pointer to the child `SomeNode`, kept alive by the underlying `IORef` that backs `child`.

The problem with this approach is that the `child` `IORef` may be reachable throughout the entire duration of the program execution (e.g., `child` is connected to a top-level `reactimate`). This is problematic, because a weak pointer is kept alive by the garbage collector if the key of the weak pointer is alive *regardless* of whether anyone actually has a reference to the weak pointer itself. In the case of `switchE`, this means any time we switch a child to have a new parent, we allocate one more weak pointer that can never be garbage collected.

The fix is to instead create these self-referential weak pointers whenever pulses, latches and outputs are created. This means that when we switch parent, we can avoid allocating new weak pointers to the (stable) child node (essentially caching the weak pointer).

Fixes #253, #152.