### PR TITLE
Increase strictness of `insertNodes`

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Evaluation.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Evaluation.hs
@@ -113,7 +113,7 @@ insertNodes (RWS.Tuple (time,_) _ _) = go
             then go xs q        -- pulse has already been put into the queue once
             else do             -- pulse needs to be scheduled for evaluation
                 put p $! (let p = Pulse{..} in p { _seenP = time })
-                go xs (Q.insert _levelP node q)
-    go (node:xs)      q = go xs (Q.insert ground node q)
+                go xs $! Q.insert _levelP node q
+    go (node:xs)      q = go xs $! Q.insert ground node q
             -- O and L nodes have only one parent, so
             -- we can insert them at an arbitrary level


### PR DESCRIPTION
I don't think there is any need for the queue returned by `insertNodes` to be lazy. `insertNodes` is immediately consumed by `go`, so this queue will eventually be forced. By moving the forcing to `insertNodes`, we slightly reduce allocations.

This can be seen by running the benchmarks once:

```
$ cabal run benchmark:benchmark -- --baseline=baseline --stdev Infinity +RTS -s
```

Before this change, running each benchmark once allocates 5,131,676,872 bytes. After this change, the total allocations drops to 4,899,397,744 bytes.