### PR TITLE
Force new `Network` after completing a step

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Evaluation.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Evaluation.hs
@@ -1,6 +1,7 @@
 {-----------------------------------------------------------------------------
     reactive-banana
 ------------------------------------------------------------------------------}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
 module Reactive.Banana.Prim.Low.Evaluation (
     step
@@ -45,7 +46,7 @@ step (inputs,pulses)
         actions = OB.inOrder outputs outputs1   -- EvalO actions in proper order
 
         state2 :: Network
-        state2  = Network
+        !state2 = Network
             { nTime    = next time1
             , nOutputs = OB.inserts outputs1 os
             , nAlwaysP = alwaysP


### PR DESCRIPTION
Minor, but currently when we step the event network we produce a new `Network`, but nothing forces this. `step` completes and returns a thunk containing the network, which gets stored in an `MVar`. This thunk isn't adding anything, so instead it would be better to just force the `Network`. We could do this either in `step` itself (as done in this commit), or we could force it when we store it the `s` `MVar`.