### PR TITLE
Implement `accumL` with `newPulse`

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Combinators.hs
@@ -98,7 +98,11 @@ applyL lf lx = cachedLatch
 accumL :: a -> Pulse (a -> a) -> Build (Latch a, Pulse a)
 accumL a p1 = do
     (updateOn, x) <- newLatch a
-    p2 <- applyP (mapL (\x f -> f x) x) p1
+    p2 <- newPulse "accumL" $ do
+      a <- readLatchP x
+      f <- readPulseP p1
+      return $ fmap (\g -> g a) f
+    p2 `dependOn` p1
     updateOn p2
     return (x,p2)
 


### PR DESCRIPTION
Currently `accumL` uses `mapL` to read the previous state whenever the state update `Pulse` fires. This is problematic, because when the previous state is read in `mapL` (and transformed into a `(a -> a) -> a` function), this is cached into the `Latch`. This means that when the state update `Pulse` fires, we'll update one latch to the new state, while also retaining the previous state. This commit redefines `accumL` as a call to `newLatch` (as before) and creates a new `Pulse` with `newPulse` whose evaluation function reads the `Pulse` containing the `a -> a` endmorphism, and also reads the current state from its latch. With this implementation, no historic values are leaked by `accumL`.