### PR TITLE
remove unused stack.yaml

### DIFF
--- a/reactive-banana/stack.yaml
+++ b/reactive-banana/stack.yaml
@@ -1,4 +1,0 @@
-# GHC-8.0.2
-resolver: lts-8.11
-packages:
-- '.'


### PR DESCRIPTION
This PR removes an old `reactive-banana/stack.yaml` that pins GHC 8.0. I assume it's no longer used or useful, but stuck around unnoticed after `reactive-banana` source was moved into a subdir.