### PR TITLE
add better error message when network lock is held

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/High/Combinators.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/High/Combinators.hs
@@ -52,7 +52,10 @@ data EventNetwork = EventNetwork
 runStep :: EventNetwork -> Prim.Step -> IO ()
 runStep EventNetwork{ actuated, s, size } f = whenFlag actuated $ do
     output <- mask $ \restore -> do
-        s1 <- takeMVar s                   -- read and take lock
+        -- read and take lock
+        s1 <- tryTakeMVar s >>= \ms -> case ms of
+          Nothing -> fail "<<informative error message goes here>>"
+          Just s1 -> pure s1
         -- pollValues <- sequence polls    -- poll mutable data
         (output, s2) <-
             restore (f s1)                 -- calculate new state


### PR DESCRIPTION
This PR adds a better error message when attempting to acquire the network lock while it is held.

I think this partially addresses #190, though we could/should also add documentation to `execute` to call out this behavior.

To do:

- [ ] Decide on an exception type. This currently uses `fail` in IO, so `IOException`. I find this kind of nasty and old-school, but this exception shouldn't really ever be caught and handled in any particular way.
- [ ] Nail down exact wording of error message
- [ ] Update `execute` documentation (and are there other common ways this can occur?)