### PR TITLE
refactor: delete Action newtype

### DIFF
--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -45,7 +45,7 @@ Library
     default-language:   Haskell98
     hs-source-dirs:     src
 
-    build-depends:      base >= 4.2 && < 5,
+    build-depends:      base >= 4.10 && < 5,
                         deepseq >= 1.4.3.0 && < 1.5,
                         semigroups >= 0.13 && < 0.21,
                         containers >= 0.5 && < 0.7,

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Evaluation.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Evaluation.hs
@@ -39,7 +39,7 @@ step (inputs,pulses)
             $  runEvalP pulses
             $  evaluatePulses inputs nGraphGC
 
-    doit latchUpdates                          -- update latch values from pulses
+    latchUpdates                               -- update latch values from pulses
     applyDependencyChanges dependencyChanges   -- rearrange graph topology
         nGraphGC
     GraphGC.removeGarbage nGraphGC             -- remove unreachable pulses

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Plumbing.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Plumbing.hs
@@ -137,7 +137,7 @@ addOutput p = do
 runBuildIO :: BuildR -> BuildIO a -> IO (a, DependencyChanges, [Output])
 runBuildIO i m = do
     (a, BuildW (topologyUpdates, os, liftIOLaters, _)) <- unfold mempty m
-    doit liftIOLaters          -- execute late IOs
+    liftIOLaters          -- execute late IOs
     return (a,topologyUpdates,os)
   where
     -- Recursively execute the  buildLater  calls.
@@ -197,7 +197,7 @@ changeParent pulse0 parent0 =
      parent = _nodeP parent0
 
 liftIOLater :: IO () -> Build ()
-liftIOLater x = RW.tell $ BuildW (mempty, mempty, Action x, mempty)
+liftIOLater x = RW.tell $ BuildW (mempty, mempty, x, mempty)
 
 {-----------------------------------------------------------------------------
     EvalL monad
@@ -246,7 +246,7 @@ readLatchFutureP :: Latch a -> EvalP (Future a)
 readLatchFutureP = return . readLatchIO
 
 rememberLatchUpdate :: IO () -> EvalP ()
-rememberLatchUpdate x = RWS.tell ((Action x,mempty),mempty)
+rememberLatchUpdate x = RWS.tell ((x,mempty),mempty)
 
 rememberOutput :: (Output, EvalO) -> EvalP ()
 rememberOutput x = RWS.tell ((mempty,[x]),mempty)

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Types.hs
@@ -47,7 +47,7 @@ type Build  = ReaderWriterIOT BuildR BuildW IO
 type BuildR = (Time, Pulse ())
     -- ( current time
     -- , pulse that always fires)
-newtype BuildW = BuildW (DependencyChanges, [Output], Action, Maybe (Build ()))
+newtype BuildW = BuildW (DependencyChanges, [Output], IO (), Maybe (Build ()))
     -- reader : current timestamp
     -- writer : ( actions that change the network topology
     --          , outputs to be added to the network
@@ -68,17 +68,6 @@ data DependencyChange parent child
     = InsertEdge parent child
     | ChangeParentTo child parent
 type DependencyChanges = [DependencyChange SomeNode SomeNode]
-
-{-----------------------------------------------------------------------------
-    Synonyms
-------------------------------------------------------------------------------}
--- | 'IO' actions as a monoid with respect to sequencing.
-newtype Action = Action { doit :: IO () }
-instance Semigroup Action where
-    Action x <> Action y = Action (x >> y)
-instance Monoid Action where
-    mempty = Action $ return ()
-    mappend = (<>)
 
 {-----------------------------------------------------------------------------
     Pulse and Latch
@@ -135,7 +124,7 @@ mkWeakNodeValue x v = Ref.mkWeak x v Nothing
 
 -- | Evaluation monads.
 type EvalPW   = (EvalLW, [(Output, EvalO)])
-type EvalLW   = Action
+type EvalLW   = IO ()
 
 type EvalO    = Future (IO ())
 type Future   = IO


### PR DESCRIPTION
A tiny PR with negligible worth but I figured I would put it up anyway ;)

This PR deletes the Action newtype in favor of IO's own semigroup instance, which has been around since GHC 8.2 (released in 2017).

Conflicts with #275 