### PR TITLE
optimize a couple graph functions

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Graph.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Graph.hs
@@ -116,14 +116,14 @@ getLevel Graph{levels} x = fromMaybe ground $ Map.lookup x levels
 -- | List all connected vertices,
 -- i.e. vertices on which at least one edge is incident.
 listConnectedVertices :: (Eq v, Hashable v) => Graph v e -> [v]
-listConnectedVertices Graph{incoming,outgoing} = 
-    Map.keys $ (() <$ outgoing) `Map.union` (() <$ incoming)
+listConnectedVertices Graph{incoming,outgoing} =
+    Map.keys $ outgoing `Map.union` incoming
 
 -- | Number of connected vertices,
 -- i.e. vertices on which at least one edge is incident.
 size :: (Eq v, Hashable v) => Graph v e -> Int
 size Graph{incoming,outgoing} =
-    Map.size $ (() <$ outgoing) `Map.union` (() <$ incoming)
+    Map.size $ outgoing `Map.union` incoming
 
 -- | Number of edges.
 edgeCount :: (Eq v, Hashable v) => Graph v e -> Int


### PR DESCRIPTION
This PR deletes a couple unnecessary O(n) `<$ ()`) calls. I suspect these were added at a time when graph `outgoing` and `incoming` had different types, but now they're the same.