### PR TITLE
delete seenP

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/IO.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/IO.hs
@@ -32,7 +32,6 @@ newInput = mdo
     _key   <- liftIO Lazy.newKey
     nodeP  <- liftIO $ Ref.new $ P $ PulseD
         { _keyP      = _key
-        , _seenP     = agesAgo
         , _evalP     = readPulseP pulse    -- get its own value
         , _nameP     = "newInput"
         }

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Plumbing.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Plumbing.hs
@@ -34,7 +34,6 @@ newPulse name eval = liftIO $ do
     _key <- Lazy.newKey
     _nodeP <- Ref.new $ P $ PulseD
         { _keyP      = _key
-        , _seenP     = agesAgo
         , _evalP     = eval
         , _nameP     = name
         }
@@ -56,7 +55,6 @@ neverP = liftIO $ do
     _key <- Lazy.newKey
     _nodeP <- Ref.new $ P $ PulseD
         { _keyP      = _key
-        , _seenP     = agesAgo
         , _evalP     = pure Nothing
         , _nameP     = "neverP"
         }

--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Types.hs
@@ -90,7 +90,6 @@ data Pulse a = Pulse
 
 data PulseD a = PulseD
     { _keyP      :: Lazy.Key (Maybe a) -- Key to retrieve pulse from cache.
-    , _seenP     :: !Time              -- See note [Timestamp].
     , _evalP     :: EvalP (Maybe a)    -- Calculate current value.
     , _nameP     :: String             -- Name for debugging.
     }
@@ -107,7 +106,7 @@ showUnique = show . hashWithSalt 0
 
 type Latch  a = Ref.Ref (LatchD a)
 data LatchD a = Latch
-    { _seenL  :: !Time               -- Timestamp for the current value.
+    { _seenL  :: !Time               -- Timestamp for the current value. See Note [Timestamp]
     , _valueL :: a                   -- Current value.
     , _evalL  :: EvalL a             -- Recalculate current latch value.
     }
@@ -200,13 +199,6 @@ instance Monoid Time where
 ------------------------------------------------------------------------------}
 {- Note [Timestamp]
 
-The time stamp indicates how recent the current value is.
-
-For Pulse:
-During pulse evaluation, a time stamp equal to the current
-time indicates that the pulse has already been evaluated in this phase.
-
-For Latch:
 The timestamp indicates the last time at which the latch has been written to.
 
     agesAgo   = The latch has never been written to.


### PR DESCRIPTION
It seems with the new internals we no longer rely on a timestamp to know if a pulse has been evaluated. Does that sound right? If so, this PR just deletes the unused field.