### PR TITLE
NOINLINE pureL

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Plumbing.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Plumbing.hs
@@ -63,6 +63,7 @@ neverP = liftIO $ do
     pure $ Pulse{_key,_nodeP}
 
 -- | Return a 'Latch' that has a constant value
+{-# NOINLINE pureL #-}
 pureL :: a -> Latch a
 pureL a = unsafePerformIO $ Ref.new $ Latch
     { _seenL  = beginning


### PR DESCRIPTION
This pragma isn't completely necessary, but feels better than not having it. We can close #37 now.