### PR TITLE
slightly defunctionalize Latch by giving it a PureL constructor

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Mid/Types.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Mid/Types.hs
@@ -93,7 +93,12 @@ instance Show (Pulse a) where
 showUnique :: Unique -> String
 showUnique = show . hashWithSalt 0
 
-type Latch  a = Ref.Ref (LatchD a)
+data Latch a
+  = PureL a
+  | ImpureL !(Latch' a)
+
+type Latch' a = Ref.Ref (LatchD a)
+
 data LatchD a = Latch
     { _seenL  :: !Time               -- Timestamp for the current value. See Note [Timestamp]
     , _valueL :: a                   -- Current value.
@@ -103,7 +108,7 @@ data LatchD a = Latch
 type LatchWrite = SomeNode
 data LatchWriteD = forall a. LatchWriteD
     { _evalLW  :: EvalP a            -- Calculate value to write.
-    , _latchLW :: Weak (Latch a)     -- Destination 'Latch' to write to.
+    , _latchLW :: Weak (Latch' a)    -- Destination 'Latch' to write to.
     }
 
 type Output  = SomeNode


### PR DESCRIPTION
This PR slightly defunctionalizes `Latch` by distinguishing (in the constructor tag) whether a latch is pure or not.

I gather from https://github.com/HeinrichApfelmus/reactive-banana/issues/37#issuecomment-1445208119 this is not necessarily the be-all end-all representation of Latch.

Nonetheless, it was easy to do, and I figured it might push the codebase forward a little bit. Feel free to close if not, though.

(Oh, some unrelated changes I see in the diff: I added an export list to `Mid.Combinators`)