### PR TITLE
slightly improve performance of getting graph size

### DIFF
--- a/reactive-banana/src/Reactive/Banana/Prim/Low/Graph.hs
+++ b/reactive-banana/src/Reactive/Banana/Prim/Low/Graph.hs
@@ -124,11 +124,11 @@ listConnectedVertices :: (Eq v, Hashable v) => Graph v e -> [v]
 listConnectedVertices Graph{incoming,outgoing} =
     Map.keys $ outgoing `Map.union` incoming
 
--- | Number of connected vertices,
+-- | O(v) Number of connected vertices,
 -- i.e. vertices on which at least one edge is incident.
 size :: (Eq v, Hashable v) => Graph v e -> Int
-size Graph{incoming,outgoing} =
-    Map.size $ outgoing `Map.union` incoming
+size Graph{levels} =
+    Map.size levels
 
 -- | Number of edges.
 edgeCount :: (Eq v, Hashable v) => Graph v e -> Int


### PR DESCRIPTION
Just something small I noticed: we got the graph size by getting the size of `union(outgoing, incoming)`, but it's also available via the size of `levels`.