### PR TITLE
Allow reactive-banana-1.3

### DIFF
--- a/reactive-banana-wx/reactive-banana-wx.cabal
+++ b/reactive-banana-wx/reactive-banana-wx.cabal
@@ -44,7 +44,7 @@ flag buildExamples
 Library
     hs-source-dirs:  src
     build-depends:   base >= 4.2 && < 5,
-                     reactive-banana >= 1.1 && < 1.3,
+                     reactive-banana >= 1.1 && < 1.4,
                      wxcore (>= 0.13.2.1 && < 0.90) || (>= 0.90.0.1 && < 0.94),
                      wx (>= 0.13.2.1 && < 0.90) || (>= 0.90.0.1 && < 0.94)
     extensions:      ExistentialQuantification

--- a/reactive-banana-wx/reactive-banana-wx.cabal
+++ b/reactive-banana-wx/reactive-banana-wx.cabal
@@ -47,7 +47,8 @@ Library
                      reactive-banana >= 1.1 && < 1.4,
                      wxcore (>= 0.13.2.1 && < 0.90) || (>= 0.90.0.1 && < 0.94),
                      wx (>= 0.13.2.1 && < 0.90) || (>= 0.90.0.1 && < 0.94)
-    extensions:      ExistentialQuantification
+    default-extensions:
+                     ExistentialQuantification
     exposed-modules: Reactive.Banana.WX
 
 Source-repository    head


### PR DESCRIPTION
I can compile reactive-banana-wx with latest reactive-banana.
Fortunately, wxhaskell:master/HEAD can built again with recent GHC versions and Nix.