### PR TITLE
Bump dependencies to allow `hashable-1.5.0.0`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,108 +1,116 @@
-name: CI
-
+name: Build cabal project
 on:
+  workflow_dispatch:
   pull_request:
+    types:
+      - synchronize
+      - opened
+      - reopened
+  merge_group:
   push:
-    branches: [master]
+    branches:
+      - master
+  schedule:
+    # Run once per day (at UTC 18:00) to maintain cache:
+    - cron: 0 18 * * *
+
+env:
+  target: 'reactive-banana'
 
 jobs:
   build:
-    name: ghc ${{matrix.ghc}}
-    runs-on: ubuntu-20.04
+    name: ${{ matrix.os }}-ghc-${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
-      fail-fast: false
       matrix:
+        allow-failure:
+          - false
+        os:
+          - ubuntu-latest
+        cabal:
+          - '3.12'
+        ghc:
+          - '8.4'
+          - '8.6'
+          - '8.8'
+          - '8.10'
+          - '9.2'
+          - '9.4'
+          - '9.6'
+          - '9.8'
+          - '9.10'
         include:
-          - ghc: '9.8.1'
-            allow-failure: true
-          - ghc: '9.6.3'
-            allow-failure: false
-          - ghc: '9.4.8 '
-            allow-failure: false
-          - ghc: '9.2.8'
-            allow-failure: false
-          - ghc: '8.10.7'
-            allow-failure: false
-          - ghc: '8.8.4'
-            allow-failure: false
-          - ghc: '8.6.5'
-            allow-failure: false
-          - ghc: '8.4.4'
-            allow-failure: false
-
+          - allow-failure: true
+            os: ubuntu-latest
+            cabal: '3.12'
+            ghc: '9.12'
     steps:
-      # Weird, the action runner fails with a 'missing -lnuma' error, but only on 8.4.4.
-      - name: Install libnuma-dev for ghc 8.4.4
-        if: matrix.ghc == '8.4.4'
+      # Weird, the action runner fails with a 'missing -lnuma' error, but only on 8.4
+      - name: Install libnuma-dev for ghc 8.4
+        if: matrix.ghc == '8.4'
         run: sudo apt-get install libnuma-dev
 
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
-        id: cache-ghc
-        name: Cache GHC
+      - name: Environment
+        uses: haskell-actions/setup@v2
+        id: setup
         with:
-          path: ~/.ghcup/*
-          key: ghcup-0-${{matrix.ghc}}
-
-      # The random number towards the beginning of the cache keys below are meant to be bumped as a crude means to clear
-      # a cache. GitHub will automatically delete caches that haven't been accessed in 7 days, but there is no way to
-      # purge one manually.
-
-      # Cache dependencies stored in ~/.cabal/store
-      - uses: actions/cache@v2
-        name: Cache dependencies
-        with:
-          path: |
-            ~/.cabal/config
-            ~/.cabal/packages/hackage.haskell.org/
-            ~/.cabal/store
-          key: cabal-1-${{matrix.ghc}}-${{hashFiles('cabal.project')}}
-          restore-keys: cabal-1-${{matrix.ghc}}-
-
-      # Cache dist-newstyle/ for fast incremental builds in CI.
-      # The main cache key includes this commit hash, so we'll always fall back to the most recent build on this branch,
-      # or master.
-      - uses: actions/cache@v2
-        name: Cache build
-        with:
-          path: dist-newstyle
-          key: dist-0-${{matrix.ghc}}-${{github.sha}}
-          restore-keys: dist-0-${{matrix.ghc}}-
-
-      # Install ghc
-      - name: Install ghc
-        if: steps.cache-ghc.outputs.cache-hit != 'true'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-          ghcup install ghc ${{matrix.ghc}}
-
-      # Add ghc to path
-      - name: Add ~/.ghcup/bin to path
-        run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-
-      - name: Cabal update
-        run: cabal update
-
-      - name: Build dependencies
-        run: cabal build reactive-banana:lib:reactive-banana --disable-optimization --only-dependencies --with-compiler ghc-${{matrix.ghc}}
-
-      # We need to build the library and tests with the default optimization level
-      # in order to test garbage collection
-      - name: Build library
-        run: cabal build reactive-banana:lib:reactive-banana --with-compiler ghc-${{matrix.ghc}}
-
-      - name: Build tests
-        run: cabal build reactive-banana:test:unit --with-compiler ghc-${{matrix.ghc}}
-
-      - name: Run tests
-        run: cabal run reactive-banana:test:unit --with-compiler ghc-${{matrix.ghc}}
-
-      - name: Generate docs
-        run: cabal haddock reactive-banana --disable-optimization --with-compiler ghc-${{matrix.ghc}}
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
 
       - name: Cabal check
         run: |
           cd reactive-banana
           cabal check
+
+      - name: Configure
+        run: |
+          cabal configure \
+            --enable-tests \
+            --enable-benchmarks \
+            --enable-documentation \
+            --test-show-details=direct \
+            --write-ghc-environment-files=always
+          cabal build ${{ env.target }} --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      # For a description of how the Caching works, see
+      # https://github.com/haskell-actions/setup?tab=readme-ov-file#model-cabal-workflow-with-caching
+      - name: Dependencies (Restore from cache)
+        uses: actions/cache/restore@v4
+        id: cache
+        env:
+          key: ${{ matrix.os }}-ghc-${{ matrix.ghc }}
+          hash: ${{ hashFiles('**/plan.json') }}
+        with:
+          key: ${{ env.key }}-${{ env.hash }}
+          restore-keys: ${{ env.key }}-
+          path: ${{ steps.setup.outputs.cabal-store }}
+
+      - name: Dependencies (Install)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cabal build ${{ env.target }} --only-dependencies
+
+      # Cache dependencies already here,
+      # so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Dependencies (Save cache)
+        uses: actions/cache/save@v4
+        # If we had an exact cache hit,
+        # trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+          path: ${{ steps.setup.outputs.cabal-store }}
+
+      - name: Build
+        run: >
+          cabal build ${{ env.target }}
+          --enable-tests
+          --enable-benchmarks
+
+      - name: Test
+        run: >
+          cabal test ${{ env.target }}

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
-packages: reactive-banana
+packages:
+  reactive-banana

--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -59,7 +59,7 @@ library
     , transformers >= 0.2 && < 0.7
     , vault == 0.3.*
     , unordered-containers >= 0.2.1.0 && < 0.3
-    , hashable >= 1.1 && < 1.5
+    , hashable >= 1.1 && < 1.6
     , pqueue >= 1.0 && < 1.6
     , stm >= 2.5 && < 2.6
     , these >= 0.2 && < 1.3

--- a/reactive-banana/reactive-banana.cabal
+++ b/reactive-banana/reactive-banana.cabal
@@ -1,7 +1,8 @@
-Name:                reactive-banana
-Version:             1.3.2.0
-Synopsis:            Library for functional reactive programming (FRP).
-Description:
+cabal-version:       1.18
+name:                reactive-banana
+version:             1.3.2.0
+synopsis:            Library for functional reactive programming (FRP).
+description:
     Reactive-banana is a library for Functional Reactive Programming (FRP).
     .
     FRP offers an elegant and concise way to express interactive programs such as graphical user interfaces, animations, computer music or robot controllers. It promises to avoid the spaghetti code that is all too common in traditional approaches to GUI programming.
@@ -17,15 +18,16 @@ Description:
     /API guide./
     Start with the "Reactive.Banana" module.
 
-Homepage:            http://wiki.haskell.org/Reactive-banana
-License:             BSD3
-License-file:        LICENSE
-Author:              Heinrich Apfelmus
-Maintainer:          Heinrich Apfelmus <apfelmus quantentunnel de>
-Category:            FRP
-Cabal-version:       1.18
-Build-type:          Simple
-Tested-with:
+homepage:            http://wiki.haskell.org/Reactive-banana
+license:             BSD3
+license-file:        LICENSE
+author:              Heinrich Apfelmus
+maintainer:          Heinrich Apfelmus <apfelmus quantentunnel de>
+category:            FRP
+
+build-type:          Simple
+
+tested-with:
     GHC == 9.6.3
   , GHC == 9.4.8
   , GHC == 9.2.8
@@ -34,112 +36,120 @@ Tested-with:
   , GHC == 8.6.5
   , GHC == 8.4.4
 
-extra-source-files:     CHANGELOG.md,
-                        doc/examples/*.hs
-extra-doc-files:        doc/*.png
+extra-source-files:
+  CHANGELOG.md
+  , doc/examples/*.hs
+extra-doc-files:
+  doc/*.png
 
-Source-repository head
-    type:               git
-    location:           https://github.com/HeinrichApfelmus/reactive-banana
-    subdir:             reactive-banana/
+source-repository head
+  type:               git
+  location:           https://github.com/HeinrichApfelmus/reactive-banana
+  subdir:             reactive-banana/
 
-Library
-    default-language:   Haskell98
-    hs-source-dirs:     src
+library
+  default-language:   Haskell98
+  hs-source-dirs:     src
 
-    build-depends:      base >= 4.2 && < 5,
-                        deepseq >= 1.4.3.0 && < 1.6,
-                        semigroups >= 0.13 && < 0.21,
-                        containers >= 0.5 && < 0.8,
-                        transformers >= 0.2 && < 0.7,
-                        vault == 0.3.*,
-                        unordered-containers >= 0.2.1.0 && < 0.3,
-                        hashable >= 1.1 && < 1.5,
-                        pqueue >= 1.0 && < 1.6,
-                        stm >= 2.5 && < 2.6,
-                        these >= 0.2 && < 1.3
+  build-depends:
+      base >= 4.2 && < 5
+    , deepseq >= 1.4.3.0 && < 1.6
+    , semigroups >= 0.13 && < 0.21
+    , containers >= 0.5 && < 0.8
+    , transformers >= 0.2 && < 0.7
+    , vault == 0.3.*
+    , unordered-containers >= 0.2.1.0 && < 0.3
+    , hashable >= 1.1 && < 1.5
+    , pqueue >= 1.0 && < 1.6
+    , stm >= 2.5 && < 2.6
+    , these >= 0.2 && < 1.3
 
-    exposed-modules:
-                        Control.Event.Handler,
-                        Reactive.Banana,
-                        Reactive.Banana.Combinators,
-                        Reactive.Banana.Frameworks,
-                        Reactive.Banana.Model,
-                        Reactive.Banana.Prim.Mid,
-                        Reactive.Banana.Prim.High.Cached,
-                        Reactive.Banana.Prim.Low.Graph,
-                        Reactive.Banana.Prim.Low.GraphGC,
-                        Reactive.Banana.Prim.Low.Ref
+  exposed-modules:
+    Control.Event.Handler
+    Reactive.Banana
+    Reactive.Banana.Combinators
+    Reactive.Banana.Frameworks
+    Reactive.Banana.Model
+    Reactive.Banana.Prim.Mid
+    Reactive.Banana.Prim.High.Cached
+    Reactive.Banana.Prim.Low.Graph
+    Reactive.Banana.Prim.Low.GraphGC
+    Reactive.Banana.Prim.Low.Ref
 
-    other-modules:
-                        Control.Monad.Trans.ReaderWriterIO,
-                        Control.Monad.Trans.RWSIO,
-                        Reactive.Banana.Prim.Low.OrderedBag,
-                        Reactive.Banana.Prim.Low.GraphTraversal,
-                        Reactive.Banana.Prim.Mid.Combinators,
-                        Reactive.Banana.Prim.Mid.Compile,
-                        Reactive.Banana.Prim.Mid.Evaluation,
-                        Reactive.Banana.Prim.Mid.IO,
-                        Reactive.Banana.Prim.Mid.Plumbing,
-                        Reactive.Banana.Prim.Mid.Test,
-                        Reactive.Banana.Prim.Mid.Types,
-                        Reactive.Banana.Prim.High.Combinators,
-                        Reactive.Banana.Types
+  other-modules:
+    Control.Monad.Trans.ReaderWriterIO
+    Control.Monad.Trans.RWSIO
+    Reactive.Banana.Prim.Low.OrderedBag
+    Reactive.Banana.Prim.Low.GraphTraversal
+    Reactive.Banana.Prim.Mid.Combinators
+    Reactive.Banana.Prim.Mid.Compile
+    Reactive.Banana.Prim.Mid.Evaluation
+    Reactive.Banana.Prim.Mid.IO
+    Reactive.Banana.Prim.Mid.Plumbing
+    Reactive.Banana.Prim.Mid.Test
+    Reactive.Banana.Prim.Mid.Types
+    Reactive.Banana.Prim.High.Combinators
+    Reactive.Banana.Types
 
-    ghc-options: -Wall -Wcompat -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-fields -Werror=partial-fields -Wno-name-shadowing
+  ghc-options: -Wall -Wcompat -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-fields -Werror=partial-fields -Wno-name-shadowing
 
 Test-Suite unit
-    default-language:   Haskell98
-    type:               exitcode-stdio-1.0
-    hs-source-dirs:     test
-    main-is:            reactive-banana-tests.hs
-    other-modules:      Reactive.Banana.Test.High.Combinators,
-                        Reactive.Banana.Test.High.Plumbing,
-                        Reactive.Banana.Test.High.Space,
-                        Reactive.Banana.Test.Mid.Space,
-                        Reactive.Banana.Test.Low.Gen,
-                        Reactive.Banana.Test.Low.Graph,
-                        Reactive.Banana.Test.Low.GraphGC
-    build-depends:      base >= 4.7 && < 5,
-                        containers,
-                        deepseq >= 1.4.3.0 && < 1.6,
-                        hashable,
-                        pqueue,
-                        reactive-banana,
-                        semigroups,
-                        transformers,
-                        tasty,
-                        tasty-hunit,
-                        tasty-quickcheck >= 0.10.1.2 && < 0.12,
-                        QuickCheck >= 2.10 && < 2.16,
-                        unordered-containers,
-                        vault,
-                        these
+  default-language:   Haskell98
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            reactive-banana-tests.hs
+  other-modules:
+    Reactive.Banana.Test.High.Combinators
+    Reactive.Banana.Test.High.Plumbing
+    Reactive.Banana.Test.High.Space
+    Reactive.Banana.Test.Mid.Space
+    Reactive.Banana.Test.Low.Gen
+    Reactive.Banana.Test.Low.Graph
+    Reactive.Banana.Test.Low.GraphGC
+  build-depends:
+    base >= 4.7 && < 5,
+    containers,
+    deepseq >= 1.4.3.0 && < 1.6,
+    hashable,
+    pqueue,
+    reactive-banana,
+    semigroups,
+    transformers,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck >= 0.10.1.2 && < 0.12,
+    QuickCheck >= 2.10 && < 2.16,
+    unordered-containers,
+    vault,
+    these
 
 Benchmark space
   default-language:     Haskell2010
   type:                 exitcode-stdio-1.0
-  build-depends:        base
-                      , reactive-banana
-                      , tasty-quickcheck
-                      , tasty
-                      , QuickCheck
+  build-depends:
+      base
+    , reactive-banana
+    , tasty-quickcheck
+    , tasty
+    , QuickCheck
   hs-source-dirs:       test
   main-is:              space.hs
-  other-modules:        Reactive.Banana.Test.Mid.Space
-                      , Reactive.Banana.Test.High.Space
+  other-modules:
+    Reactive.Banana.Test.Mid.Space
+    Reactive.Banana.Test.High.Space
   ghc-options:        -rtsopts -eventlog
 
 
 Benchmark benchmark
   default-language:     Haskell2010
   type:                 exitcode-stdio-1.0
-  build-depends:        base
-                      , reactive-banana
-                      , containers
-                      , random
-                      , tasty
-                      , tasty-bench
+  build-depends:
+    base
+    , reactive-banana
+    , containers
+    , random
+    , tasty
+    , tasty-bench
   hs-source-dirs:       benchmark
   main-is:              Main.hs
   ghc-options:          "-with-rtsopts=-A32m"


### PR DESCRIPTION
This pull request updates the CI (with earlier cache of dependencies, but dropping the build cache) and bumps dependencies.